### PR TITLE
Development

### DIFF
--- a/onyx/utils/fields.py
+++ b/onyx/utils/fields.py
@@ -1,61 +1,5 @@
-from datetime import date, datetime
 from django.db import models
-from django.core.exceptions import ValidationError
-from django.utils.dateparse import parse_date
 from django.utils.translation import gettext_lazy as _
-from django.utils import timezone
-from django.conf import settings
-
-
-# TODO: This might be largely redundant
-class YearMonthField(models.DateField):
-    """
-    Minimal override of DateField to support YYYY-MM format.
-    """
-
-    default_error_messages = {
-        "invalid": _(
-            "“%(value)s” value has an invalid date format. It must be "
-            "in YYYY-MM format."
-        ),
-        "invalid_date": _(
-            "“%(value)s” value has the correct format (YYYY-MM) "
-            "but it is an invalid date."
-        ),
-    }
-    description = _("Date (without time OR day)")
-
-    def to_python(self, value):
-        if value is None:
-            return value
-
-        if isinstance(value, datetime):
-            if settings.USE_TZ and timezone.is_aware(value):
-                # Convert aware datetimes to the default time zone
-                # before casting them to dates (#17742).
-                default_timezone = timezone.get_default_timezone()
-                value = timezone.make_naive(value, default_timezone)
-            return value.date()
-
-        if isinstance(value, date):
-            return value
-
-        if isinstance(value, str):
-            try:
-                parsed = parse_date(value + "-01")
-                if parsed is not None:
-                    return parsed
-            except ValueError:
-                raise ValidationError(
-                    self.error_messages["invalid_date"],
-                    code="invalid_date",
-                    params={"value": value},
-                )
-        raise ValidationError(
-            self.error_messages["invalid"],
-            code="invalid",
-            params={"value": value},
-        )
 
 
 class ModelChoiceField(models.ForeignKey):
@@ -101,6 +45,10 @@ class UpperCharField(StrippedCharField):
 
         value = value.upper()
         return super().to_python(value)
+
+
+class YearMonthField(models.DateField):
+    pass
 
 
 class ChoiceField(models.TextField):

--- a/onyx/utils/fieldserializers.py
+++ b/onyx/utils/fieldserializers.py
@@ -100,8 +100,10 @@ class ChoiceField(serializers.ChoiceField):
 
 class HashField(serializers.CharField):
     def to_internal_value(self, data):
+        data = super().to_internal_value(data).strip().lower()
+
         hasher = hashlib.sha256()
-        hasher.update(data.strip().lower().encode("utf-8"))
+        hasher.update(data.encode("utf-8"))
         data = hasher.hexdigest()
 
-        return super().to_internal_value(data)
+        return data


### PR DESCRIPTION
- Date and datetime filtering can take `today` as input instead of a date, to filter by the current day
- Hashfield cleaning done before hashing
- Yearmonth model field is now just inheriting from Datefield with no adjustments, this is because the field serializer for Yearmonth already does all the work and its best not to have unnecessary logic which is not properly tested. The Yearmonth model field would only have ever made a difference if changing a value directly on the model with no prior cleaning, which never happens