### PR TITLE
Development

### DIFF
--- a/onyx/data/utils.py
+++ b/onyx/data/utils.py
@@ -1,16 +1,18 @@
 from contextlib import contextmanager
 from django.db import models
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from rest_framework import exceptions
-from utils.fields import YearMonthField, ModelChoiceField, ChoiceField, HashField
-from .filters import TEXT_FIELDS, DATE_FIELDS, ALL_LOOKUPS
+from utils.fields import HashField, ChoiceField, YearMonthField, TEXT_FIELDS
+from .filters import ALL_LOOKUPS
+from utils.functions import get_suggestions
+from accounts.models import User
 from .models import Choice
 
 
 @contextmanager
 def mutable(obj):
     """
-    If the provided `obj` has a `_mutable` property, this context manager temporarily sets it to `True`
+    If the provided `obj` has a `_mutable` property, this context manager temporarily sets it to `True`.
     """
     _mutable = getattr(obj, "_mutable", None)
     if _mutable is not None:
@@ -24,139 +26,19 @@ def mutable(obj):
             obj._mutable = _mutable
 
 
-def parse_dunders(obj):
+class FieldInfo:
     """
-    Flatten a JSON object into a set of dunderised keys.
+    Class for storing information on a field.
     """
-    dunders = []
-    if isinstance(obj, dict):
-        for key, item in obj.items():
-            prefix = key
-            values = parse_dunders(item)
 
-            if values:
-                for v in values:
-                    dunders.append(f"{prefix}__{v}")
-            else:
-                dunders.append(prefix)
-
-    elif isinstance(obj, list):
-        for item in obj:
-            values = parse_dunders(item)
-
-            for v in values:
-                dunders.append(v)
-    else:
-        return []
-
-    return list(set(dunders))
-
-
-def prefetch_nested(qs, fields, prefix=None):
-    """
-    For each field in `fields` that contains nested data, apply prefetching to the QuerySet `qs`.
-    """
-    for field, nested in fields.items():
-        if nested:
-            if prefix:
-                field = f"{prefix}__{field}"
-
-            qs = qs.prefetch_related(field)
-            qs = prefetch_nested(qs, nested, prefix=field)
-
-    return qs
-
-
-# TODO: Not sure the best way to use this, but its here if I need it.
-def lowercase_keys(obj):
-    """
-    Create a new object from the provided JSON object, with lowercased keys.
-    """
-    if isinstance(obj, dict):
-        return {key.lower(): lowercase_keys(value) for key, value in obj.items()}
-
-    elif isinstance(obj, list):
-        return [lowercase_keys(item) for item in obj]
-
-    else:
-        return obj
-
-
-def assign_field_types(fields, field_types, prefix=None):
-    for field, nested in fields.items():
-        if prefix:
-            field_path = f"{prefix}__{field}"
-        else:
-            field_path = field
-
-        if nested:
-            assign_field_types(nested, field_types, prefix=field_path)
-        else:
-            field_type = field_types[field_path].field_type
-            field_instance = field_types[field_path].field_instance
-
-            if field_type == HashField:
-                fields[field] = {
-                    "type": "hash",
-                    "required": not field_instance.blank,
-                }
-
-            elif field_type in TEXT_FIELDS:
-                fields[field] = {
-                    "type": "text",
-                    "required": not field_instance.blank,
-                }
-
-            elif field_type == ChoiceField:
-                choices = Choice.objects.filter(
-                    project=field_types[field_path].project, field=field
-                ).values_list("choice", flat=True)
-                fields[field] = {
-                    "type": "choice",
-                    "required": not field_instance.blank,
-                    "values": choices,
-                }
-
-            elif field_type == models.IntegerField:
-                fields[field] = {
-                    "type": "numeric",
-                    "required": not field_instance.null,
-                    "format": "integer",
-                }
-
-            elif field_type == models.FloatField:
-                fields[field] = {
-                    "type": "numeric",
-                    "required": not field_instance.null,
-                    "format": "decimal",
-                }
-
-            elif field_type == YearMonthField:
-                fields[field] = {
-                    "type": "date",
-                    "required": not field_instance.null,
-                    "format": "YYYY-MM",
-                }
-
-            elif field_type in DATE_FIELDS:
-                fields[field] = {
-                    "type": "date",
-                    "required": not field_instance.null,
-                    "format": "YYYY-MM-DD",
-                }
-
-            elif field_type == models.BooleanField:
-                fields[field] = {
-                    "type": "bool",
-                    "required": not field_instance.null,
-                }
-
-
-# TODO: All the below needs some serious TLC
-
-
-class OnyxField:
-    def __init__(self, project, field_model, field_path, field_name, lookup):
+    def __init__(
+        self,
+        project: str,
+        field_model: type[models.Model],
+        field_path: str,
+        field_name: str,
+        lookup: str,
+    ):
         self.project = project
         self.field_model = field_model
         self.field_instance = self.field_model._meta.get_field(field_name)
@@ -166,20 +48,24 @@ class OnyxField:
         self.lookup = lookup
 
 
-def resolve_fields(project, user, action, fields):
+def resolve_fields(
+    code: str,
+    model: type[models.Model],
+    fields: list[str],
+) -> tuple[dict[str, FieldInfo], list[str]]:
     """
-    * Resolves provided `fields`, determining which models they come from.
+    Resolves provided `fields`, determining which models they come from.
 
-    * Checks `user` permissions to view and perform given `action` on these.
+    This information is returned in `FieldInfo` objects.
     """
-    model = project.content_type.model_class()
+
     resolved = {}
     unknown = []
 
     # Resolve each field
     for field in fields:
-        # Check for trailing double underscore
-        if field.endswith("__"):
+        # Check for trailing underscore
+        if field.endswith("_"):
             unknown.append(field)
             continue
 
@@ -204,179 +90,337 @@ def resolve_fields(project, user, action, fields):
             field_name = field_path.split("__")[-1]
             lookup = "__".join(components[i + 1 :])
 
-            # The component is a foreign key relationship
-            if isinstance(component_instance, models.ForeignKey):
-                # TODO: Handle db_choice_fields (or omit them entirely?)
-
-                if not lookup or lookup in ALL_LOOKUPS:
-                    # The field is determined, and the lookup is recognised
-                    # So we instantiate the resolved field instance
-                    resolved[field] = OnyxField(
-                        project=project.code,
-                        field_model=current_model,
-                        field_path=field_path,
-                        field_name=field_name,
-                        lookup=lookup,
-                    )
-                    break
-                else:
-                    if isinstance(component_instance, ModelChoiceField):
-                        # A ModelChoiceField can only be followed by a valid lookup
-                        # If it is invalid, return unknown
-                        unknown.append(field)
-
-                # These may be remaining components
-                # Move on to them
-                current_model = component_instance.related_model
-
-                model_fields = {
-                    x.name: x for x in current_model._meta.get_fields()  # type: ignore
-                }
-                continue
-
-            # The component is a many-to-one relationship
-            elif isinstance(component_instance, models.ManyToOneRel):
-                if not lookup or lookup in ALL_LOOKUPS:
-                    # The field is determined, and the lookup is recognised
-                    # So we instantiate the resolved field instance
-                    resolved[field] = OnyxField(
-                        project=project.code,
-                        field_model=current_model,
-                        field_path=field_path,
-                        field_name=field_name,
-                        lookup=lookup,
-                    )
-                    break
-
-                # These may be remaining components
-                # Move on to them
-                current_model = component_instance.related_model
-
-                model_fields = {
-                    x.name: x for x in current_model._meta.get_fields()  # type: ignore
-                }
-                continue
-
-            # The component is not a relation
-            else:  # not component_instance.is_relation
-                if not lookup or lookup in ALL_LOOKUPS:
-                    # The field is determined, and the lookup is recognised
-                    # So we instantiate the resolved field instance
-                    resolved[field] = OnyxField(
-                        project=project.code,
-                        field_model=current_model,
-                        field_path=field_path,
-                        field_name=field_name,
-                        lookup=lookup,
-                    )
-                else:
-                    unknown.append(field)
-
+            if not lookup or lookup in ALL_LOOKUPS:
+                # The field is determined, and the lookup is recognised
+                # So we instantiate the resolved field instance
+                resolved[field] = FieldInfo(
+                    project=code,
+                    field_model=current_model,
+                    field_path=field_path,
+                    field_name=field_name,
+                    lookup=lookup,
+                )
                 break
 
-    required = []
+            if component_instance.is_relation:
+                # These may be remaining components
+                # Move on to them
+                current_model = component_instance.related_model
+                assert current_model is not None
 
-    app_label = project.content_type.app_label
-
-    # Get and check each field permission required by the user
-    for field_path, field_obj in resolved.items():
-        # Check whether the user can perform the action on the field
-        field_permission = (
-            f"{app_label}.{action}_{project.code}__{field_obj.field_path}"
-        )
-        if not user.has_perm(field_permission):
-            # If they do not have permission, check whether they can view the field
-            # If they can't view the field, tell them it doesn't exist
-            # If they can, return the permissions required
-            view_field_permission = (
-                f"{app_label}.view_{project.code}__{field_obj.field_path}"
-            )
-
-            if action != "view" and user.has_perm(view_field_permission):
-                required.append(field_permission)
+                model_fields = {x.name: x for x in current_model._meta.get_fields()}
                 continue
             else:
-                unknown.append(field_path)
-                continue
+                unknown.append(field)
+                break
 
-    if unknown:
-        raise exceptions.ValidationError({"unknown_fields": unknown})
-
-    if required:
-        raise exceptions.PermissionDenied(
-            {"required_permissions": sorted(set(required))}
-        )
-
-    return resolved
+    return resolved, unknown
 
 
-def get_fields_from_permissions(fields_dict, permissions, include=None, exclude=None):
-    for permission in permissions:
-        _, _, field = permission.codename.partition("__")
+def assign_fields_info(
+    fields_dict: dict,
+    fields_info: dict[str, FieldInfo],
+    prefix: str | None = None,
+) -> dict:
+    for field, nested in fields_dict.items():
+        if prefix:
+            field_path = f"{prefix}__{field}"
+        else:
+            field_path = field
 
-        if include and not any(field.startswith(inc) for inc in include):
-            continue
+        if nested:
+            assign_fields_info(
+                fields_dict=nested,
+                fields_info=fields_info,
+                prefix=field_path,
+            )
+        else:
+            field_type = fields_info[field_path].field_type
+            field_instance = fields_info[field_path].field_instance
 
-        if exclude and any(field.startswith(exc) for exc in exclude):
-            continue
+            if field_type == HashField:
+                fields_dict[field] = {
+                    "type": "hash",
+                    "required": not field_instance.blank,
+                }
 
-        field_path = field.split("__")
+            elif field_type in TEXT_FIELDS:
+                fields_dict[field] = {
+                    "type": "text",
+                    "required": not field_instance.blank,
+                }
 
-        if field_path:
+            elif field_type == ChoiceField:
+                choices = Choice.objects.filter(
+                    project=fields_info[field_path].project, field=field
+                ).values_list("choice", flat=True)
+                fields_dict[field] = {
+                    "type": "choice",
+                    "required": not field_instance.blank,
+                    "values": choices,
+                }
+
+            elif field_type == models.IntegerField:
+                fields_dict[field] = {
+                    "type": "numeric",
+                    "required": not field_instance.null,
+                    "format": "integer",
+                }
+
+            elif field_type == models.FloatField:
+                fields_dict[field] = {
+                    "type": "numeric",
+                    "required": not field_instance.null,
+                    "format": "decimal",
+                }
+
+            elif field_type == YearMonthField:
+                fields_dict[field] = {
+                    "type": "date",
+                    "required": not field_instance.null,
+                    "format": "YYYY-MM",
+                }
+
+            elif field_type in [models.DateField, models.DateTimeField]:
+                fields_dict[field] = {
+                    "type": "date",
+                    "required": not field_instance.null,
+                    "format": "YYYY-MM-DD",
+                }
+
+            elif field_type == models.BooleanField:
+                fields_dict[field] = {
+                    "type": "bool",
+                    "required": not field_instance.null,
+                }
+
+    return fields_dict
+
+
+def get_field_from_permission(
+    permission: Permission,
+) -> str:
+    _, _, field = permission.codename.partition("__")
+    return field
+
+
+def get_fields(
+    code: str,
+    action: str,
+    scopes: list[str] | None = None,
+) -> list[str]:
+    if scopes:
+        scopes = ["base"] + scopes
+    else:
+        scopes = ["base"]
+
+    groups = Group.objects.filter(
+        projectgroup__project__code=code,
+        projectgroup__action=action,
+        projectgroup__scope__in=scopes,
+    )
+
+    permissions = [
+        permission for group in groups for permission in group.permissions.all()
+    ]
+
+    fields = [get_field_from_permission(permission) for permission in permissions]
+
+    return fields
+
+
+# TODO: A lack of type-checking is required on obj in order for request.data to pass.
+# Which does make me wonder: is this robust against whatever could be provided through request.data?
+# E.g. how sure are we that all 'fields' have been flattened from obj?
+def flatten_fields(obj) -> list[str]:
+    """
+    Flatten a JSON-like `obj` into a list of dunderised keys.
+    """
+
+    dunders = []
+    if isinstance(obj, dict):
+        for key, item in obj.items():
+            prefix = key
+            values = flatten_fields(item)
+
+            if values:
+                for v in values:
+                    dunders.append(f"{prefix}__{v}")
+            else:
+                dunders.append(prefix)
+
+    elif isinstance(obj, list):
+        for item in obj:
+            values = flatten_fields(item)
+
+            for v in values:
+                dunders.append(v)
+    else:
+        return []
+
+    return list(set(dunders))
+
+
+def unflatten_fields(
+    fields: list[str],
+) -> dict:
+    fields_dict = {}
+
+    for field in fields:
+        field_pieces = field.split("__")
+
+        if field_pieces:
             current_dict = fields_dict
 
-            for p in field_path:
-                if not p:
+            for piece in field_pieces:
+                if not piece:
                     # Ignore empty strings
                     # These come from permissions where there is no field attached
                     # So there is no __ to split on
                     break
 
-                current_dict.setdefault(p, {})
-                current_dict = current_dict[p]
+                current_dict.setdefault(piece, {})
+                current_dict = current_dict[piece]
 
     return fields_dict
 
 
-def view_fields(code, scopes=None, include=None, exclude=None):
-    project_view_group = Group.objects.get(
-        projectgroup__project__code=code,
-        projectgroup__action="view",
-        projectgroup__scope="base",
-    )
-
-    if scopes:
-        scope_view_groups = [
-            Group.objects.get(
-                projectgroup__project__code=code,
-                projectgroup__action="view",
-                projectgroup__scope=scope,
-            )
-            for scope in scopes
+def include_exclude_fields(
+    fields: list[str],
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> list[str]:
+    if include:
+        fields = [
+            field for field in fields if any(field.startswith(inc) for inc in include)
         ]
-    else:
-        scope_view_groups = []
 
-    # Dictionary structure detailing all viewable fields based on
-    # the project code and the scopes provided
-    fields_dict = {}
+    if exclude:
+        fields = [
+            field
+            for field in fields
+            if not any(field.startswith(exc) for exc in exclude)
+        ]
 
-    # Update the fields dict with all viewable fields in the base project
-    fields_dict = get_fields_from_permissions(
-        fields_dict,
-        project_view_group.permissions.all(),
-        include=include,
-        exclude=exclude,
+    return fields
+
+
+def get_user_fields(
+    user: User,
+    code: str,
+    action: str,
+) -> list[str]:
+    groups = user.groups.filter(
+        projectgroup__project__code=code,
+        projectgroup__action=action,
     )
 
-    # For each scope
-    # Update the fields dict with any additional viewable fields
-    for scope_view_group in scope_view_groups:
-        fields_dict = get_fields_from_permissions(
-            fields_dict,
-            scope_view_group.permissions.all(),
-            include=include,
-            exclude=exclude,
-        )
+    permissions = [
+        permission for group in groups for permission in group.permissions.all()
+    ]
 
-    return fields_dict
+    fields = [get_field_from_permission(permission) for permission in permissions]
+
+    return fields
+
+
+def validate_fields(
+    user: User,
+    code: str,
+    app_label: str,
+    action: str,
+    fields: list[str],
+    required: list[str] | None = None,
+    unknown: list[str] | None = None,
+) -> None:
+    if not required:
+        required = []
+
+    if not unknown:
+        unknown = []
+
+    for field in fields:
+        # Check whether the user can perform the action on the field
+        field_action_permission = f"{app_label}.{action}_{code}__{field}"
+
+        if not user.has_perm(field_action_permission):
+            # If they do not have permission, check whether they can view the field
+            field_view_permission = f"{app_label}.view_{code}__{field}"
+
+            if action != "view" and user.has_perm(field_view_permission):
+                # If the user has permission to view the field, return the action permission required
+                required.append(field)
+            else:
+                # If the user does not have permission, tell them it is unknown
+                unknown.append(field)
+
+    # Form error messages for fields with permissions required
+    required_dict = {}
+    for r in required:
+        required_dict[r] = [f"You cannot {action} this field."]
+
+    # Form error messages for unknown fields
+    unknown_dict = {}
+    if unknown:
+        user_fields = get_user_fields(user, code, action)
+
+        for u in unknown:
+            suggestions = get_suggestions(u, fields=user_fields)
+
+            if suggestions:
+                unknown_dict[u] = [
+                    f"This field is unknown. Perhaps you meant: {', '.join(suggestions)}"
+                ]
+            else:
+                unknown_dict[u] = ["This field is unknown."]
+
+    errors = unknown_dict | required_dict
+
+    if errors:
+        raise exceptions.ValidationError(errors)
+
+
+def init_project_queryset(
+    model: type[models.Model],
+    user: User,
+    fields: list[str] | None = None,
+) -> models.manager.BaseManager[models.Model]:
+    qs = model.objects.select_related()
+
+    if not user.is_staff:
+        # If the user is not a member of staff:
+        # - Ignore suppressed data
+        # - Ignore site_restricted objects from other sites
+        qs = qs.filter(suppressed=False).exclude(
+            models.Q(site_restricted=True) & ~models.Q(user__site=user.site)
+        )
+    elif fields and "suppressed" not in fields:
+        # If the user is a member of staff, but the suppressed field is not in scope:
+        # - Ignore suppressed data
+        qs = qs.filter(suppressed=False)
+
+    return qs
+
+
+def prefetch_nested(
+    qs: models.QuerySet,
+    fields_dict: dict,
+    prefix: str | None = None,
+) -> models.QuerySet:
+    """
+    For each field in `fields_dict` that contains nested data, apply prefetching to the QuerySet `qs`.
+    """
+
+    for field, nested in fields_dict.items():
+        if nested:
+            if prefix:
+                field = f"{prefix}__{field}"
+
+            qs = qs.prefetch_related(field)
+            qs = prefetch_nested(
+                qs=qs,
+                fields_dict=nested,
+                prefix=field,
+            )
+
+    return qs

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -154,6 +154,9 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "internal.renderers.OnyxJSONRenderer",
     ],
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
+    ],
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_PAGINATION_CLASS": None,
     "PAGE_SIZE": 1000,

--- a/onyx/utils/fields.py
+++ b/onyx/utils/fields.py
@@ -57,3 +57,13 @@ class ChoiceField(models.TextField):
 
 class HashField(models.TextField):
     pass
+
+
+# All text field types
+TEXT_FIELDS = [
+    models.CharField,
+    models.TextField,
+    StrippedCharField,
+    LowerCharField,
+    UpperCharField,
+]

--- a/onyx/utils/functions.py
+++ b/onyx/utils/functions.py
@@ -1,0 +1,24 @@
+import difflib
+
+
+def get_suggestions(unknown: str, fields: list[str], n=4, cutoff=0.4) -> list[str]:
+    fields_map = {field.lower().strip(): field for field in fields}
+
+    close_matches = difflib.get_close_matches(
+        word=unknown.lower().strip(),
+        possibilities=fields_map.keys(),
+        n=n,
+        cutoff=cutoff,
+    )
+
+    return [fields_map[close_match] for close_match in close_matches]
+
+
+def strtobool(val):
+    val = val.lower()
+    if val == "true":
+        return True
+    elif val == "false":
+        return False
+    else:
+        raise ValueError(f"Invalid truth value: {val}")


### PR DESCRIPTION
- Default parser classes is now JSON only, meaning only JSON is accepted as the request body content-type
- Functions utility file where `strtobool` has been moved to, as well as new `get_suggestions` function that performs a case-insensitive similarity test of a string to a set of strings, using the `difflib.get_close_matches` function.
- `data.filters` reorganised with clearer lookup definitions, `ModelChoice` removed, and suggestions for `Choice`.
- `data.views` revamped with better typing and more granular field manipulation done by new functions in `data.utils`, as well as integration of suggestions for unknown fields and choices.
- `/projects/` endpoint now returns users' available actions on each project.