### PR TITLE
Updated the data.serializers __init__ to make ModelSerializerMap more…

### DIFF
--- a/onyx/data/serializers/__init__.py
+++ b/onyx/data/serializers/__init__.py
@@ -1,22 +1,51 @@
 import pkgutil
-import importlib
+import importlib, inspect
+from django.db.models import Model
+from rest_framework.serializers import ModelSerializer
 from . import projects
-from .serializers import SerializerNode
+from .serializers import SerializerNode, ProjectRecordSerializer
 
 
 class ModelSerializerMap:
     MAPPING = {}
 
     @classmethod
-    def get(cls, model):
-        return cls.MAPPING.get(model)
+    def add(cls, model: type[Model], serializer: type[ModelSerializer]):
+        """
+        Add a `Model` and its `ModelSerializer` to the `ModelSerializerMap`.
+        """
+        cls.MAPPING[model] = serializer
 
     @classmethod
-    def update(cls, mapping):
-        cls.MAPPING = cls.MAPPING | mapping
+    def get(cls, model: type[Model]) -> type[ModelSerializer]:
+        """
+        Retrieve the `ModelSerializer` for a `Model`.
+        """
+        return cls.MAPPING[model]
 
 
-for module in pkgutil.iter_modules(projects.__path__):
-    mod = importlib.import_module(f".projects.{module.name}", package=__package__)
-    if hasattr(mod, "mapping"):
-        ModelSerializerMap.update(mod.mapping)
+for module_info in pkgutil.iter_modules(
+    path=projects.__path__,
+    prefix=".projects.",
+):
+    module = importlib.import_module(
+        name=module_info.name,
+        package=__package__,
+    )
+
+    # Predicate that ensures members satisfy the following:
+    # - The member is a subclass of ProjectRecordSerializer
+    # - The member has a Meta.model attribute
+    predicate = (
+        lambda x: inspect.isclass(x)
+        and issubclass(x, ProjectRecordSerializer)
+        and hasattr(x.Meta, "model")
+    )
+
+    # For each member of the module that satisfies the predicate
+    # Add it to the mapping
+    for name, cls in inspect.getmembers(module, predicate):
+        ModelSerializerMap.add(
+            model=cls.Meta.model,
+            serializer=cls,
+        )

--- a/onyx/data/serializers/projects/test.py
+++ b/onyx/data/serializers/projects/test.py
@@ -102,6 +102,3 @@ class TestModelSerializer(BaseTestModelSerializer):
                 },
             }
         }
-
-
-mapping = {TestModel: TestModelSerializer}


### PR DESCRIPTION
… magic

- Basically, the `serializers.py` file for a project no longer needs to define a `mapping` dictionary for it to be picked up and added to the `ModelSerializerMap`.