### PR TITLE
Fixed regex filter, allowed numbers in URL usernames, bumped django-filter from 23.3 to 23.4

### DIFF
--- a/onyx/accounts/urls.py
+++ b/onyx/accounts/urls.py
@@ -10,12 +10,12 @@ urlpatterns = [
     path("profile/", views.ProfileView.as_view()),
     path("waiting/", views.WaitingUsersView.as_view()),
     re_path(
-        r"^approve/(?P<username>[a-zA-Z_\.\-]*)/$", views.ApproveUserView.as_view()
+        r"^approve/(?P<username>[a-zA-Z0-9_\.\-]*)/$", views.ApproveUserView.as_view()
     ),
     path("site/", views.SiteUsersView.as_view()),
     path("all/", views.AllUsersView.as_view()),
     re_path(
-        r"^projectuser/(?P<code>[a-zA-Z_]*)/(?P<site_code>[a-zA-Z]*)/(?P<username>[a-zA-Z_\.\-]*)/$",
+        r"^projectuser/(?P<code>[a-zA-Z_]*)/(?P<site_code>[a-zA-Z]*)/(?P<username>[a-zA-Z0-9_\.\-]*)/$",
         views.ProjectUserView.as_view(),
     ),
 ]

--- a/onyx/data/filters.py
+++ b/onyx/data/filters.py
@@ -1,3 +1,4 @@
+import re
 import hashlib
 from datetime import datetime
 from django import forms
@@ -31,8 +32,17 @@ class CharInFilter(filters.BaseInFilter, filters.CharFilter):
     pass
 
 
-class CharRangeFilter(filters.BaseRangeFilter, filters.CharFilter):
-    pass
+class RegexForm(forms.CharField):
+    def validate(self, value):
+        super().validate(value)
+        try:
+            re.compile(value)
+        except re.error as e:
+            raise ValidationError(f"Invalid pattern: {e}")
+
+
+class RegexFilter(filters.Filter):
+    field_class = RegexForm
 
 
 class ChoiceFieldMixin:
@@ -205,7 +215,8 @@ FILTERS = {
     OnyxType.TEXT: {lookup: filters.CharFilter for lookup in OnyxType.TEXT.lookups}
     | {
         "in": CharInFilter,
-        "range": CharRangeFilter,
+        "regex": RegexFilter,
+        "iregex": RegexFilter,
     },
     OnyxType.CHOICE: {lookup: ChoiceFilter for lookup in OnyxType.CHOICE.lookups}
     | {

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,13 +209,13 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-filter"
-version = "23.3"
+version = "23.4"
 description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "django-filter-23.3.tar.gz", hash = "sha256:015fe155582e1805b40629344e4a6cf3cc40450827d294d040b4b8c1749a9fa6"},
-    {file = "django_filter-23.3-py3-none-any.whl", hash = "sha256:65bc5d1d8f4fff3aaf74cb5da537b6620e9214fb4b3180f6c560776b1b6dccd0"},
+    {file = "django-filter-23.4.tar.gz", hash = "sha256:bed070b38359dce7d2dbe057b165d59773057986356cb809ded983b36c77a976"},
+    {file = "django_filter-23.4-py3-none-any.whl", hash = "sha256:526954f18bd7d6423f232a9a7974f58fbc6863908b9fc160de075e01adcc2a5f"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.7.2"
+version = "0.7.3"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Addressed internal server error triggered by invalid regex pattern passed to the `regex` and `iregex` filter which raised an uncaught `DatabaseError`. This has been 'fixed' by checking for compilation of the pattern before passing it to the database. The compilation does occur again, so there may be some edge-cases missed between `re.compile` and the `regex` lookup. But we will just have to see...
- Updated `username` URL regex to allow usernames with numbers`0-9`.
- Updated poetry.lock file to bump `django-filter` from version 23.3 to 23.4.