### PR TITLE
SQLite is only used for tests with CI environment flag, updated .gitignore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,6 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
-    services:
-      postgres:
-        image: postgres:14
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: onyx
-        ports:
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-    
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -42,11 +30,8 @@ jobs:
       env:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
-        DATABASE_HOST: 127.0.0.1
-        DATABASE_PORT: 5432
         DATABASE_NAME: onyx
-        DATABASE_USER: postgres
-        DATABASE_PASSWORD: postgres
+        DATABASE_USER: onyx
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_USER: onyx
-          POSTGRES_PASSWORD: onyx
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: onyx
         ports:
           - 5432:5432
@@ -43,7 +43,7 @@ jobs:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
         DATABASE_NAME: onyx
-        DATABASE_USER: onyx
+        DATABASE_USER: postgres
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,10 @@ jobs:
         poetry config virtualenvs.in-project true
         poetry env use ${{ matrix.python-version }}
         poetry install --with test
-    - name: Set up database
+    - name: Create Database
       run: |
         sudo systemctl start postgresql.service
+        sudo -u postgres psql -c "CREATE ROLE root WITH CREATEDB"
         sudo -u postgres psql -c "CREATE DATABASE onyx OWNER root;"
 
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,11 @@ jobs:
       env:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
+        DATABASE_HOST: 127.0.0.1
+        DATABASE_PORT: 5432
         DATABASE_NAME: onyx
         DATABASE_USER: postgres
+        DATABASE_PASSWORD: postgres
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,18 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: onyx
+          POSTGRES_PASSWORD: onyx
+          POSTGRES_DB: onyx
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,18 +38,12 @@ jobs:
         poetry config virtualenvs.in-project true
         poetry env use ${{ matrix.python-version }}
         poetry install --with test
-    - name: Create Database
-      run: |
-        sudo systemctl start postgresql.service
-        sudo -u postgres psql -c "CREATE ROLE root WITH CREATEDB"
-        sudo -u postgres psql -c "CREATE DATABASE onyx OWNER root;"
-
     - name: Run Tests
       env:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
         DATABASE_NAME: onyx
-        DATABASE_USER: root
+        DATABASE_USER: onyx
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,16 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
+    services:
+      postgres:
+        image: postgres:14.10
+        env:
+          POSTGRES_DB: onyx
+          POSTGRES_USER: onyx
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,8 +40,8 @@ jobs:
       env:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
-        DATABASE_NAME: db-not-found
-        DATABASE_USER: user-not-found
+        DATABASE_NAME: onyx
+        DATABASE_USER: onyx
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
     services:
       postgres:
         image: postgres:14.10
-        env:
-          POSTGRES_DB: onyx
-          POSTGRES_USER: onyx
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
@@ -41,7 +38,7 @@ jobs:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
         DATABASE_NAME: onyx
-        DATABASE_USER: onyx
+        DATABASE_USER: postgres
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,6 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
-    services:
-      postgres:
-        image: postgres:14.10
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,6 +26,11 @@ jobs:
         poetry config virtualenvs.in-project true
         poetry env use ${{ matrix.python-version }}
         poetry install --with test
+    - name: Set up database
+      run: |
+        sudo systemctl start postgresql.service
+        sudo -u postgres psql -c "CREATE DATABASE onyx;"
+
     - name: Run Tests
       env:
         SECRET_KEY: super-duper-secret-key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,14 @@ jobs:
     - name: Set up database
       run: |
         sudo systemctl start postgresql.service
-        sudo -u postgres psql -c "CREATE DATABASE onyx;"
+        sudo -u postgres psql -c "CREATE DATABASE onyx OWNER root;"
 
     - name: Run Tests
       env:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
         DATABASE_NAME: onyx
-        DATABASE_USER: postgres
+        DATABASE_USER: root
       working-directory: ./onyx
       run: |
         poetry run coverage run --source='.' manage.py test -v 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 .venv
 .env
 .coverage
+.stuff
 **.log
 __pycache__
 migrations
-stuff
 onyx/data/models/projects/*
 !onyx/data/models/projects/__init__.py
 !onyx/data/models/projects/test.py

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -96,8 +96,11 @@ WSGI_APPLICATION = "onyx.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
+        "HOST": os.environ["DATABASE_HOST"],
+        "PORT": os.environ["DATABASE_PORT"],
         "NAME": os.environ["DATABASE_NAME"],
         "USER": os.environ["DATABASE_USER"],
+        "PASSWORD": os.environ["DATABASE_PASSWORD"],
     }
 }
 

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -96,13 +96,17 @@ WSGI_APPLICATION = "onyx.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "HOST": os.environ["DATABASE_HOST"],
-        "PORT": os.environ["DATABASE_PORT"],
         "NAME": os.environ["DATABASE_NAME"],
         "USER": os.environ["DATABASE_USER"],
-        "PASSWORD": os.environ["DATABASE_PASSWORD"],
     }
 }
+
+# TODO: Use Postgres for Github Actions
+if os.environ.get("GITHUB_WORKFLOW") and "test" in sys.argv:
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "testdb",
+    }
 
 
 # Password validation

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -101,8 +101,8 @@ DATABASES = {
     }
 }
 
-# TODO: Use Postgres for Github Actions
-if os.environ.get("GITHUB_WORKFLOW") and "test" in sys.argv:
+# TODO: Use Postgres for CI testing instead of SQLite
+if os.environ.get("CI") and "test" in sys.argv:
     DATABASES["default"] = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": "testdb",

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -101,14 +101,6 @@ DATABASES = {
     }
 }
 
-# TODO: A bit hacky but okay for now
-# In the long run we should probably use postgres for tests as well
-if "test" in sys.argv:
-    DATABASES["default"] = {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "testdb",
-    }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.0/ref/settings/#auth-password-validators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.9.0"
+version = "0.9.1"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Previously SQLite was used for any and all running of `python manage.py test`, as it was (and currently is) a lot easier to run CI tests using SQLite rather than PostgreSQL. However, running tests locally would preferably be done using PostgreSQL. This small update changes behaviour such that SQLite is only used for tests if the `CI` environment variable is set, a variable which is set to `true` in Github action workflows.
- The .gitignore `stuff` folder was changed to `.stuff`.