### PR TITLE
Improved tests, generate_fields_spec relational fields can have descriptions, increased max summary count

### DIFF
--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -392,38 +392,36 @@ def generate_fields_spec(
         else:
             field_path = field
 
-        if nested:
-            onyx_type = onyx_fields[field_path].onyx_type
-            required = onyx_fields[field_path].required
+        onyx_type = onyx_fields[field_path].onyx_type
+        field_instance = onyx_fields[field_path].field_instance
+        required = onyx_fields[field_path].required
+
+        if onyx_type == OnyxType.RELATION:
             generate_fields_spec(
                 fields_dict=nested,
                 onyx_fields=onyx_fields,
                 prefix=field_path,
             )
             fields_dict[field] = {
+                "description": field_instance.field.help_text,  #  type: ignore
                 "type": onyx_type.label,
                 "required": required,
                 "fields": nested,
             }
+        elif onyx_type == OnyxType.CHOICE:
+            choices = onyx_fields[field_path].choices
+            fields_dict[field] = {
+                "description": field_instance.help_text,
+                "type": onyx_type.label,
+                "required": required,
+                "values": choices,
+            }
         else:
-            onyx_type = onyx_fields[field_path].onyx_type
-            field_instance = onyx_fields[field_path].field_instance
-            required = onyx_fields[field_path].required
-
-            if onyx_type == OnyxType.CHOICE:
-                choices = onyx_fields[field_path].choices
-                fields_dict[field] = {
-                    "description": field_instance.help_text,
-                    "type": onyx_type.label,
-                    "required": required,
-                    "values": choices,
-                }
-            else:
-                fields_dict[field] = {
-                    "description": field_instance.help_text,
-                    "type": onyx_type.label,
-                    "required": required,
-                }
+            fields_dict[field] = {
+                "description": field_instance.help_text,
+                "type": onyx_type.label,
+                "required": required,
+            }
 
     return fields_dict
 

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -100,7 +100,6 @@ class BaseRecord(models.Model):
     # site = models.ForeignKey(Site, to_field="code", on_delete=models.CASCADE)
 
     class Meta:
-        default_permissions = []
         abstract = True
 
     @classmethod
@@ -143,12 +142,7 @@ class ProjectRecord(BaseRecord):
     )
 
     class Meta:
-        default_permissions = []
         abstract = True
-        indexes = [
-            models.Index(fields=["published_date"]),
-            models.Index(fields=["suppressed"]),
-        ]
 
     def save(self, *args, **kwargs):
         if not self.pk:

--- a/onyx/data/models/projects/test.py
+++ b/onyx/data/models/projects/test.py
@@ -34,6 +34,11 @@ class BaseTestModel(ProjectRecord):
     class Meta:
         default_permissions = []
         indexes = [
+            models.Index(fields=["created"]),
+            models.Index(fields=["climb_id"]),
+            models.Index(fields=["published_date"]),
+            models.Index(fields=["suppressed"]),
+            models.Index(fields=["site_restricted"]),
             models.Index(fields=["sample_id", "run_name"]),
             models.Index(fields=["sample_id"]),
             models.Index(fields=["run_name"]),
@@ -54,7 +59,9 @@ class BaseTestModel(ProjectRecord):
                 fields=["text_option_1", "text_option_2"],
             ),
             conditional_required(
-                model_name="basetestmodel", field="region", required=["country"]
+                model_name="basetestmodel",
+                field="region",
+                required=["country"],
             ),
         ]
 
@@ -78,17 +85,21 @@ class TestModelRecord(BaseRecord):
 
     class Meta:
         default_permissions = []
+        indexes = [
+            models.Index(fields=["created"]),
+            models.Index(fields=["link", "test_id"]),
+        ]
         constraints = [
             unique_together(
-                model_name="testmodelrecords",
+                model_name="testmodelrecord",
                 fields=["link", "test_id"],
             ),
             optional_value_group(
-                model_name="testmodelrecords",
+                model_name="testmodelrecord",
                 fields=["score_a", "score_b"],
             ),
             conditional_required(
-                model_name="testmodelrecords",
+                model_name="testmodelrecord",
                 field="score_c",
                 required=["score_a", "score_b"],
             ),

--- a/onyx/data/tests/utils.py
+++ b/onyx/data/tests/utils.py
@@ -56,6 +56,10 @@ def generate_test_data(n=100):
     Generate test data.
     """
 
+    # TODO: Better generation of test data
+    # - Empty values for testing isnull without requiring allow_empty = True
+    # - More distinct float, dates etc for testing exact filter matches without requiring allow_empty = True
+
     data = []
     for i in range(n):
         country_region_group = random.randint(0, 4)

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -444,7 +444,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
                 raise exceptions.ValidationError(summary_errors)
 
             qs_summary_values = qs.values(*self.summarise)
-            if qs_summary_values.distinct().count() > 10000:
+            if qs_summary_values.distinct().count() > 100000:
                 raise exceptions.ValidationError(
                     {
                         "detail": "The current summary would return too many distinct values."
@@ -463,8 +463,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
             self.paginator.ordering = "created"
 
             # Paginate the response
-            instances = qs.order_by("id")
-            result_page = self.paginator.paginate_queryset(instances, request)
+            result_page = self.paginator.paginate_queryset(qs, request)
 
             # Serialize the results
             serializer = self.serializer_cls(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.9.1"
+version = "0.9.2"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Improved tests for filtering on text and choice fields
- `generate_fields_spec` function can now use the help_text from a nested foreign key to describe the table
- Removed unused indexes from abstract models
- Increased summary count limit from 10,000 to 100,000