### PR TITLE
Explicitly migrate apps to get postgres working in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,18 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
 
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: onyx
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -31,8 +43,11 @@ jobs:
         SECRET_KEY: super-duper-secret-key
         HOST_NAME: localhost
         DATABASE_NAME: onyx
-        DATABASE_USER: onyx
+        DATABASE_USER: postgres
+        DATABASE_PASSWORD: postgres
+        DATABASE_HOST: localhost
       working-directory: ./onyx
       run: |
+        poetry run python manage.py makemigrations accounts data internal
         poetry run coverage run --source='.' manage.py test -v 2
         poetry run coverage report

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -101,13 +101,18 @@ DATABASES = {
     }
 }
 
-# TODO: Use Postgres for CI testing instead of SQLite
+# In CI, Django has to connect differently to the Postgres container,
+# and we have to provide a host name and password
 if os.environ.get("CI") and "test" in sys.argv:
-    DATABASES["default"] = {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "testdb",
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ["DATABASE_NAME"],
+            "USER": os.environ["DATABASE_USER"],
+            "PASSWORD": os.environ["DATABASE_PASSWORD"],
+            "HOST": os.environ["DATABASE_HOST"],
+        }
     }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/4.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Until the migrations are committed to the repo, Django doesn't know how to create and migrate the test DB, which leads to various errors (which seldom seem to put at the absence of migrations). This PR mainly adds a line to the test workflow to explicitly migrate the apps in this project:
```
poetry run python manage.py makemigrations accounts data internal
```
In the CI, Django has to connect to the DB running in a container, for which it seems we have to provide a hostname and password, so there's a conditional block that redefines Django's DB configuration if it detects CI (through the env var `CI`) and the command arguments include `test`.