### PR TITLE
Fix non-future constraint, added missing constraints on test models

### DIFF
--- a/onyx/data/models/projects/test.py
+++ b/onyx/data/models/projects/test.py
@@ -4,6 +4,8 @@ from utils.fields import YearMonthField, StrippedCharField, ChoiceField
 from utils.constraints import (
     unique_together,
     optional_value_group,
+    ordering,
+    non_futures,
     conditional_required,
 )
 
@@ -58,6 +60,18 @@ class BaseTestModel(ProjectRecord):
                 model_name="basetestmodel",
                 fields=["text_option_1", "text_option_2"],
             ),
+            ordering(
+                model_name="basetestmodel",
+                fields=("collection_month", "received_month"),
+            ),
+            ordering(
+                model_name="basetestmodel",
+                fields=("start", "end"),
+            ),
+            non_futures(
+                model_name="basetestmodel",
+                fields=["collection_month", "received_month", "submission_date"],
+            ),
             conditional_required(
                 model_name="basetestmodel",
                 field="region",
@@ -97,6 +111,10 @@ class TestModelRecord(BaseRecord):
             optional_value_group(
                 model_name="testmodelrecord",
                 fields=["score_a", "score_b"],
+            ),
+            ordering(
+                model_name="testmodelrecord",
+                fields=("test_start", "test_end"),
             ),
             conditional_required(
                 model_name="testmodelrecord",

--- a/onyx/utils/constraints.py
+++ b/onyx/utils/constraints.py
@@ -40,6 +40,10 @@ def ordering(model_name: str, fields: tuple[str, str]):
     )
 
 
+# TODO: BROKEN
+# The reason it keeps self adding/removing is because it changes each time the date changes
+# So it's not a static constraint
+# Could be fixed by doing a comparison to e.g. the last_modified date
 def non_futures(model_name: str, fields: list[str]):
     return models.CheckConstraint(
         check=functools.reduce(

--- a/onyx/utils/constraints.py
+++ b/onyx/utils/constraints.py
@@ -1,14 +1,26 @@
 import functools
 import operator
-from datetime import datetime
 from django.db import models
-from django.db.models import Q
+from django.db.models import F, Q
 
 
 # TODO: Test constraints
 
 
 def unique_together(model_name: str, fields: list[str]):
+    """
+    Creates a unique constraint over the provided `fields`.
+
+    This means that the combination of these fields in a given instance must be unique across all other instances.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        fields: The fields to create the constraint over.
+
+    Returns:
+        The constraint.
+    """
+
     return models.UniqueConstraint(
         fields=fields,
         name=f"unique_together_{model_name}_{'_'.join(fields)}",
@@ -16,10 +28,26 @@ def unique_together(model_name: str, fields: list[str]):
 
 
 def optional_value_group(model_name: str, fields: list[str]):
+    """
+    Creates a constraint that ensures at least one of the provided `fields` is not null.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        fields: The fields to create the constraint over.
+
+    Returns:
+        The constraint.
+    """
+
+    # For each field, build a Q object that requires the field is not null
+    q_objects = [Q(**{f"{field}__isnull": False}) for field in fields]
+
+    # Reduce the Q objects into a single Q object that requires at least one of the fields is not null
+    # This is done by OR-ing the Q objects together
+    check = functools.reduce(operator.or_, q_objects)
+
     return models.CheckConstraint(
-        check=functools.reduce(
-            operator.or_, [Q(**{f"{field}__isnull": False}) for field in fields]
-        ),
+        check=check,
         name=f"optional_value_group_{model_name}_{'_'.join(fields)}",
         violation_error_message="At least one of '"
         + "', '".join(fields)
@@ -28,32 +56,63 @@ def optional_value_group(model_name: str, fields: list[str]):
 
 
 def ordering(model_name: str, fields: tuple[str, str]):
+    """
+    Creates a constraint that ensures the first field is less than or equal to the second field.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        fields: The fields to create the constraint over.
+
+    Returns:
+        The constraint.
+    """
+
+    # Split the fields tuple into lower and higher
     lower, higher = fields
+
+    # Build a Q object that requires that either:
+    # - One of the two fields is null
+    # - The lower field is less than or equal to the higher field
+    check = (
+        models.Q(**{f"{lower}__isnull": True})
+        | models.Q(**{f"{higher}__isnull": True})
+        | models.Q(**{f"{lower}__lte": models.F(higher)})
+    )
+
     return models.CheckConstraint(
-        check=(
-            models.Q(**{f"{lower}__isnull": True})
-            | models.Q(**{f"{higher}__isnull": True})
-            | models.Q(**{f"{lower}__lte": models.F(higher)})
-        ),
+        check=check,
         name=f"ordering_{model_name}_{lower}_{higher}",
         violation_error_message=f"The '{lower}' must be less than or equal to '{higher}'.",
     )
 
 
-# TODO: BROKEN
-# The reason it keeps self adding/removing is because it changes each time the date changes
-# So it's not a static constraint
-# Could be fixed by doing a comparison to e.g. the last_modified date
 def non_futures(model_name: str, fields: list[str]):
+    """
+    Creates a constraint that ensures that the provided `fields` are not from the future.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        fields: The fields to create the constraint over.
+
+    Returns:
+        The constraint.
+    """
+
+    # For each field, build a Q object that requires the field is null or less than or equal to the last_modified field
+    q_objects = [
+        Q(**{f"{field}__isnull": True}) | Q(**{f"{field}__lte": F("last_modified")})
+        for field in fields
+    ]
+
+    # Reduce the Q objects into a single Q object that requires all of the fields are not from the future
+    # This is done by AND-ing the Q objects together
+    check = functools.reduce(
+        operator.and_,
+        q_objects,
+    )
+
     return models.CheckConstraint(
-        check=functools.reduce(
-            operator.and_,
-            [
-                Q(**{f"{field}__isnull": True})
-                | ~Q(**{f"{field}__gt": datetime.now().date()})
-                for field in fields
-            ],
-        ),
+        check=check,
         name=f"non_future_{model_name}_{'_'.join(fields)}",
         violation_error_message="At least one of '"
         + "', '".join(fields)
@@ -62,11 +121,31 @@ def non_futures(model_name: str, fields: list[str]):
 
 
 def conditional_required(model_name: str, field: str, required: list[str]):
+    """
+    Creates a constraint that ensures that the provided `field` must be null unless all of the `required` fields are not null.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        field: The field to create the constraint over.
+        required: The fields that are required in order to set the `field`.
+
+    Returns:
+        The constraint.
+    """
+
+    # For each required field, build a Q object that requires the field is not null
+    q_objects = [Q(**{f"{req}__isnull": False}) for req in required]
+
+    # Reduce the Q objects into a single Q object that requires all of the required fields are not null
+    requirements = functools.reduce(operator.and_, q_objects)
+
+    # Build a Q object that requires that either:
+    # - The field is null
+    # - All of the required fields are not null
+    check = Q(**{f"{field}__isnull": True}) | requirements
+
     return models.CheckConstraint(
-        check=Q(**{f"{field}__isnull": True})
-        | functools.reduce(
-            operator.and_, [Q(**{f"{req}__isnull": False}) for req in required]
-        ),
+        check=check,
         name=f"conditional_required_{model_name}_{field}_requires_{'_'.join(required)}",
         violation_error_message="All of '"
         + "', '".join(required)


### PR DESCRIPTION
- Any `non_futures` constraints were, for a while, auto-regenerating on each migration. I didn't pay much attention to it...
- I should have done because there was an obvious bug! The `datetime.now().date()` was hardcoding a new maximum date each time, rather than representing a continuously 'now' value. This is pretty obvious once I noticed it...
- The fix has been to replace this `datetime` object with a Django `F` object for the `last_modified` attribute, which is present on all `BaseRecord` instances. This means a model with this constraint on their field will enforce that the fields value is either `null` or LTE to the `last_modified` value on that same instance, which is a continuously updated value.
- The test models `BaseTestModel` and `TestModelRecord` were missing some database-level constraints for `ordering` and `non_futures`, so these have been added.