### PR TITLE
Identify endpoint returns 404 rather than 400 when identifier is not found

### DIFF
--- a/onyx/data/exceptions.py
+++ b/onyx/data/exceptions.py
@@ -4,3 +4,7 @@ from rest_framework import exceptions
 
 class ClimbIDNotFound(exceptions.NotFound):
     default_detail = _("CLIMB ID not found.")
+
+
+class IdentifierNotFound(exceptions.NotFound):
+    default_detail = _("Identifier not found.")

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -17,7 +17,7 @@ from .serializers import (
     SummarySerializer,
     IdentifierSerializer,
 )
-from .exceptions import ClimbIDNotFound
+from .exceptions import ClimbIDNotFound, IdentifierNotFound
 from .query import make_atoms, validate_atoms, make_query
 from .queryset import init_project_queryset, prefetch_nested
 from .types import OnyxType
@@ -267,9 +267,7 @@ class IdentifyView(ProjectAPIView):
         try:
             anonymised_field = field_serializer.anonymiser_model.objects.get(hash=hash)
         except field_serializer.anonymiser_model.DoesNotExist:
-            raise exceptions.ValidationError(
-                {"detail": "No identifier exists for this value."}
-            )
+            raise IdentifierNotFound
 
         # Return field, value and identifier
         return Response(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.10.1"
+version = "0.10.2"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- The `IdentifyView` now returns a `404` rather than a `400` when no corresponding identifier is found for a value.