### PR TITLE
Data endpoint for retrieving identifiers, testing `Anonymiser` model

### DIFF
--- a/onyx/data/exceptions.py
+++ b/onyx/data/exceptions.py
@@ -4,3 +4,7 @@ from rest_framework import exceptions
 
 class ClimbIDNotFound(exceptions.NotFound):
     default_detail = _("CLIMB ID not found.")
+
+
+class IdentifierNotFound(exceptions.NotFound):
+    default_detail = _("Identifier not found.")

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -33,7 +33,18 @@ class ProjectGroup(models.Model):
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     action = LowerCharField(
         max_length=10,
-        choices=[(x, x) for x in ["add", "view", "change", "delete"]],
+        choices=[
+            (x, x)
+            for x in [
+                "add",
+                "view",
+                "filter",
+                "summarise",
+                "identify",
+                "change",
+                "delete",
+            ]
+        ],
     )
     scope = LowerCharField(max_length=50, default="base")
 

--- a/onyx/data/models/projects/test.py
+++ b/onyx/data/models/projects/test.py
@@ -1,6 +1,6 @@
 from django.db import models
-from ..models import BaseRecord, ProjectRecord
-from utils.fields import YearMonthField, StrippedCharField, ChoiceField
+from ..models import BaseRecord, ProjectRecord, Anonymiser
+from utils.fields import YearMonthField, UpperCharField, ChoiceField
 from utils.constraints import (
     unique_together,
     optional_value_group,
@@ -13,15 +13,40 @@ from utils.constraints import (
 __version__ = "0.1.0"
 
 
+class TestSampleID(Anonymiser):
+    @classmethod
+    def get_identifier_prefix(cls):
+        return "S"
+
+    class Meta:
+        default_permissions = []
+        indexes = [
+            models.Index(fields=["hash"]),
+        ]
+
+
+class TestRunName(Anonymiser):
+    @classmethod
+    def get_identifier_prefix(cls):
+        return "R"
+
+    class Meta:
+        default_permissions = []
+        indexes = [
+            models.Index(fields=["hash"]),
+        ]
+
+
 class BaseTestModel(ProjectRecord):
     @classmethod
     def version(cls):
         return __version__
 
-    sample_id = StrippedCharField(max_length=24)
-    run_name = StrippedCharField(max_length=96)
+    sample_id = UpperCharField()
+    run_name = UpperCharField()
     collection_month = YearMonthField(null=True)
     received_month = YearMonthField(null=True)
+    char_max_length_20 = models.CharField(max_length=20)
     text_option_1 = models.TextField(blank=True)
     text_option_2 = models.TextField(blank=True)
     submission_date = models.DateField(null=True)

--- a/onyx/data/serializers/__init__.py
+++ b/onyx/data/serializers/__init__.py
@@ -2,7 +2,12 @@ import pkgutil
 import importlib, inspect
 from django.db.models import Model
 from . import projects
-from .serializers import ProjectRecordSerializer, SerializerNode, SummarySerializer
+from .serializers import (
+    ProjectRecordSerializer,
+    SerializerNode,
+    SummarySerializer,
+    IdentifierSerializer,
+)
 
 
 class ProjectSerializerMap:

--- a/onyx/data/serializers/projects/test.py
+++ b/onyx/data/serializers/projects/test.py
@@ -1,7 +1,13 @@
 from utils.validators import OnyxUniqueTogetherValidator
 from ..serializers import BaseRecordSerializer, ProjectRecordSerializer
-from ...models.projects.test import BaseTestModel, TestModel, TestModelRecord
-from utils.fieldserializers import ChoiceField, YearMonthField
+from ...models.projects.test import (
+    BaseTestModel,
+    TestModel,
+    TestModelRecord,
+    TestSampleID,
+    TestRunName,
+)
+from utils.fieldserializers import ChoiceField, YearMonthField, AnonymiserField
 
 
 class TestModelRecordSerializer(BaseRecordSerializer):
@@ -34,6 +40,8 @@ class TestModelRecordSerializer(BaseRecordSerializer):
 
 
 class BaseTestModelSerializer(ProjectRecordSerializer):
+    sample_id = AnonymiserField(TestSampleID)
+    run_name = AnonymiserField(TestRunName)
     collection_month = YearMonthField(required=False, allow_null=True)
     received_month = YearMonthField(required=False, allow_null=True)
     country = ChoiceField("test", "country", required=False, allow_blank=True)
@@ -46,6 +54,7 @@ class BaseTestModelSerializer(ProjectRecordSerializer):
             "run_name",
             "collection_month",
             "received_month",
+            "char_max_length_20",
             "text_option_1",
             "text_option_2",
             "submission_date",
@@ -87,6 +96,10 @@ class BaseTestModelSerializer(ProjectRecordSerializer):
         conditional_required = ProjectRecordSerializer.OnyxMeta.conditional_required | {
             "region": ["country"]
         }
+        action_success_fields = (
+            ProjectRecordSerializer.OnyxMeta.action_success_fields
+            + ["sample_id", "run_name"]
+        )
 
 
 class TestModelSerializer(BaseTestModelSerializer):

--- a/onyx/data/serializers/serializers.py
+++ b/onyx/data/serializers/serializers.py
@@ -43,6 +43,14 @@ class SummarySerializer(serializers.Serializer):
         super().__init__(*args, **kwargs)
 
 
+class IdentifierSerializer(serializers.Serializer):
+    """
+    Serializer for input to the `data.project.identify` endpoint.
+    """
+
+    value = serializers.CharField()
+
+
 # https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields
 class BaseRecordSerializer(serializers.ModelSerializer):
     """

--- a/onyx/data/tests/project.json
+++ b/onyx/data/tests/project.json
@@ -12,6 +12,7 @@
                 "run_name",
                 "collection_month",
                 "received_month",
+                "char_max_length_20",
                 "text_option_1",
                 "text_option_2",
                 "submission_date",
@@ -42,6 +43,7 @@
                 "run_name",
                 "collection_month",
                 "received_month",
+                "char_max_length_20",
                 "text_option_1",
                 "text_option_2",
                 "submission_date",
@@ -68,6 +70,7 @@
             "fields": [
                 "collection_month",
                 "received_month",
+                "char_max_length_20",
                 "text_option_1",
                 "text_option_2",
                 "submission_date",
@@ -86,6 +89,14 @@
                 "records__score_a",
                 "records__score_b",
                 "records__score_c"
+            ]
+        },
+        {
+            "action": "identify",
+            "scope": "base",
+            "fields": [
+                "sample_id",
+                "run_name"
             ]
         },
         {

--- a/onyx/data/tests/utils.py
+++ b/onyx/data/tests/utils.py
@@ -69,6 +69,7 @@ def generate_test_data(n=100):
             "run_name": f"run-{random.randint(1, 3)}",
             "collection_month": f"2022-{random.randint(1, 12)}",
             "received_month": f"2023-{random.randint(1, 6)}",
+            "char_max_length_20": "X" * 20,
             "text_option_1": random.choice(["hi", ""]),
             "text_option_2": "bye",
             "submission_date": f"2023-{random.randint(1, 6)}-{random.randint(1, 25)}",
@@ -131,6 +132,9 @@ def _test_record(self, payload, instance, created=False):
         payload.get("received_month"),
         instance.received_month.strftime("%Y-%m") if instance.received_month else None,
     )
+    self.assertEqual(payload.get("char_max_length_20", ""), instance.char_max_length_20)
+    self.assertEqual(payload.get("text_option_1", ""), instance.text_option_1)
+    self.assertEqual(payload.get("text_option_2", ""), instance.text_option_2)
     self.assertEqual(
         payload.get("submission_date"),
         instance.submission_date.strftime("%Y-%m-%d")
@@ -142,6 +146,8 @@ def _test_record(self, payload, instance, created=False):
     self.assertEqual(payload.get("concern"), instance.concern)
     self.assertEqual(payload.get("tests"), instance.tests)
     self.assertEqual(payload.get("score"), instance.score)
+    self.assertEqual(payload.get("start"), instance.start)
+    self.assertEqual(payload.get("end"), instance.end)
 
     # If the payload has nested records, check the correctness of these
     if payload.get("records"):

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -19,6 +19,7 @@ default_payload = {
     "run_name": "run-5678",
     "collection_month": "2023-01",
     "received_month": "2023-02",
+    "char_max_length_20": "X" * 20,
     "text_option_1": "hi",
     "text_option_2": "bye",
     "submission_date": "2023-03-01",
@@ -71,6 +72,8 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 1
         assert TestModelRecord.objects.count() == 2
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
         _test_record(self, payload, instance, created=True)
 
     def test_basic_test(self):
@@ -125,6 +128,8 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 1
         assert TestModelRecord.objects.count() == 2
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
         _test_record(self, payload, instance, created=True)
 
     def test_unpermissioned_viewable_field(self):
@@ -224,6 +229,8 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 1
         assert TestModelRecord.objects.count() == 2
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
         _test_record(self, payload, instance, created=True)
 
     def test_unique_together(self):
@@ -237,6 +244,10 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 1
         assert TestModelRecord.objects.count() == 2
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        default_sample_id_identifier = payload["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
+        default_run_name_identifier = payload["run_name"]
         _test_record(self, payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
@@ -246,6 +257,8 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 2
         assert TestModelRecord.objects.count() == 4
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
         _test_record(self, payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
@@ -255,6 +268,8 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 3
         assert TestModelRecord.objects.count() == 6
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
         _test_record(self, payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
@@ -263,11 +278,11 @@ class TestCreateView(OnyxTestCase):
         assert TestModel.objects.count() == 3
         assert TestModelRecord.objects.count() == 6
         assert (
-            TestModel.objects.filter(sample_id=default_payload["sample_id"]).count()
+            TestModel.objects.filter(sample_id=default_sample_id_identifier).count()
             == 2
         )
         assert (
-            TestModel.objects.filter(run_name=default_payload["run_name"]).count() == 2
+            TestModel.objects.filter(run_name=default_run_name_identifier).count() == 2
         )
 
     def test_nested_unique_together(self):
@@ -421,7 +436,7 @@ class TestCreateView(OnyxTestCase):
         """
 
         payload = copy.deepcopy(default_payload)
-        payload["sample_id"] = "A" * 1000 + "H"
+        payload["char_max_length_20"] = "X" * 21
         response = self.client.post(self.endpoint, data=payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0
@@ -458,6 +473,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -504,6 +521,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -549,6 +568,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -593,6 +614,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -644,6 +667,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -694,6 +719,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 
@@ -739,6 +766,8 @@ class TestCreateView(OnyxTestCase):
             instance = TestModel.objects.get(
                 climb_id=response.json()["data"]["climb_id"]
             )
+            payload["sample_id"] = response.json()["data"]["sample_id"]
+            payload["run_name"] = response.json()["data"]["run_name"]
             _test_record(self, payload, instance, created=True)
             TestModel.objects.all().delete()
 

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -1,0 +1,50 @@
+from django.contrib.auth.models import Group
+from rest_framework import status
+from rest_framework.reverse import reverse
+from ..utils import OnyxTestCase, generate_test_data
+
+
+# TODO: Tests for identify endpoint
+class TestIdentifyView(OnyxTestCase):
+    def setUp(self):
+        """
+        Create a user with the required permissions and create a test record.
+        """
+
+        super().setUp()
+        self.endpoint = lambda field: reverse(
+            "data.project.identify", kwargs={"code": "test", "field": field}
+        )
+        self.user = self.setup_user(
+            "testuser", roles=["is_staff"], groups=["test.identify.base"]
+        )
+
+        self.user.groups.add(Group.objects.get(name="test.add.base"))
+        test_record = next(iter(generate_test_data(n=1)))
+        self.input_sample_id = test_record["sample_id"]
+        self.input_run_name = test_record["run_name"]
+        response = self.client.post(
+            reverse("data.project", kwargs={"code": "test"}),
+            data=test_record,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.output_sample_id = response.json()["data"]["sample_id"]
+        self.output_run_name = response.json()["data"]["run_name"]
+        self.user.groups.remove(Group.objects.get(name="test.add.base"))
+
+    def test_basic(self):
+        """
+        Test retrieving identifiers for anonymised fields.
+        """
+
+        response = self.client.post(
+            self.endpoint("sample_id"), data={"value": self.input_sample_id}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["identifier"], self.output_sample_id)
+
+        response = self.client.post(
+            self.endpoint("run_name"), data={"value": self.input_run_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["identifier"], self.output_run_name)

--- a/onyx/data/urls.py
+++ b/onyx/data/urls.py
@@ -52,4 +52,9 @@ urlpatterns = [
         views.ChoicesView.as_view(),
         name="data.project.choices",
     ),
+    re_path(
+        r"^(?P<code>[a-zA-Z_]*)/identify/(?P<field>[a-zA-Z0-9_]*)/$",
+        views.IdentifyView.as_view(),
+        name="data.project.identify",
+    ),
 ]

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -17,7 +17,7 @@ from .serializers import (
     SummarySerializer,
     IdentifierSerializer,
 )
-from .exceptions import ClimbIDNotFound
+from .exceptions import ClimbIDNotFound, IdentifierNotFound
 from .query import make_atoms, validate_atoms, make_query
 from .queryset import init_project_queryset, prefetch_nested
 from .types import OnyxType
@@ -267,9 +267,7 @@ class IdentifyView(ProjectAPIView):
         try:
             anonymised_field = field_serializer.anonymiser_model.objects.get(hash=hash)
         except field_serializer.anonymiser_model.DoesNotExist:
-            raise exceptions.ValidationError(
-                {"detail": "No identifier exists for this value."}
-            )
+            raise IdentifierNotFound
 
         # Return field, value and identifier
         return Response(

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import hashlib
 from pydantic import RootModel, ValidationError as PydanticValidationError
 from django.db.models import Count
 from rest_framework import status, exceptions
@@ -7,9 +8,15 @@ from rest_framework.response import Response
 from rest_framework.pagination import CursorPagination
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSetMixin
+from utils.fieldserializers import AnonymiserField
 from accounts.permissions import Approved, ProjectApproved, ProjectAdmin
 from .models import Project, Choice, ProjectRecord
-from .serializers import ProjectSerializerMap, SerializerNode, SummarySerializer
+from .serializers import (
+    ProjectSerializerMap,
+    SerializerNode,
+    SummarySerializer,
+    IdentifierSerializer,
+)
 from .exceptions import ClimbIDNotFound
 from .query import make_atoms, validate_atoms, make_query
 from .queryset import init_project_queryset, prefetch_nested
@@ -224,6 +231,54 @@ class ChoicesView(ProjectAPIView):
 
         # Return choices for the field
         return Response(choices)
+
+
+class IdentifyView(ProjectAPIView):
+    permission_classes = ProjectApproved
+    project_action = "identify"
+
+    def post(self, request: Request, code: str, field: str) -> Response:
+        """
+        Retrieve the identifier for a given `value` of the given `field`.
+        """
+
+        # Validate the request field
+        try:
+            self.handler.resolve_field(field)
+        except exceptions.ValidationError as e:
+            raise exceptions.ValidationError({"detail": e.args[0]})
+
+        # Determine the field serializer
+        field_serializer = self.serializer_cls().get_fields()[field]  # type: ignore
+        assert isinstance(field_serializer, AnonymiserField)
+
+        # Validate request body
+        serializer = IdentifierSerializer(data=self.request_data)
+        if not serializer.is_valid():
+            raise exceptions.ValidationError(serializer.errors)
+
+        # Hash the value
+        value = serializer.data["value"]  #  type: ignore
+        hasher = hashlib.sha256()
+        hasher.update(value.strip().lower().encode("utf-8"))
+        hash = hasher.hexdigest()
+
+        # Get the anonymised field data from the hash
+        try:
+            anonymised_field = field_serializer.anonymiser_model.objects.get(hash=hash)
+        except field_serializer.anonymiser_model.DoesNotExist:
+            raise exceptions.ValidationError(
+                {"detail": "No identifier exists for this value."}
+            )
+
+        # Return field, value and identifier
+        return Response(
+            {
+                "field": field,
+                "value": value,
+                "identifier": anonymised_field.identifier,
+            }
+        )
 
 
 class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.10.1"
+version = "0.10.2"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Added new data endpoint: `IdentifyView`
- This view enables retrieval of the anonymised identifier for a provided field's value. With this, users who know the prior pre-anonymised value can lookup its corresponding identifier and retrieve their data from onyx.
- Updated `sample_id` and `run_name` fields in `BaseTestModel` to use the `Anonymiser` to anonymise their field values.
- Added initial test for `IdentifyView`.
- Swapped to dedicated field for testing max char length parameter, `char_max_length_20`, on `BaseTestModel`. This is because issue https://github.com/CLIMB-TRE/onyx/issues/105 has found that anonymised fields don't (currently) work with `max_length` validation on the original value, and one of the anonymised fields, `sample_id`, was previously being used for this validation test.