### PR TITLE
Project group/permissions refactor, improved field spec generation

### DIFF
--- a/onyx/accounts/exceptions.py
+++ b/onyx/accounts/exceptions.py
@@ -6,10 +6,6 @@ class ProjectNotFound(exceptions.NotFound):
     default_detail = _("Project not found.")
 
 
-class ScopeNotFound(exceptions.NotFound):
-    default_detail = _("Scope not found.")
-
-
 class UserNotFound(exceptions.NotFound):
     default_detail = _("User not found.")
 

--- a/onyx/accounts/management/commands/user.py
+++ b/onyx/accounts/management/commands/user.py
@@ -158,24 +158,22 @@ def list_users():
             value = getattr(user, role)
             attrs[role.removeprefix("is_").lower()] = value
 
-        groups = []
-
-        # Filter user groups to determine all distinct (code, scope) pairs
-        for project_scope in (
-            user.groups.filter(projectgroup__isnull=False)
-            .values(
-                "projectgroup__project__code",
-                "projectgroup__scope",
+        # Filter user groups to determine all distinct code[scope] values
+        project_groups = [
+            f"{project}[{scope}]"
+            for project, scope in (
+                user.groups.filter(projectgroup__isnull=False)
+                .values_list(
+                    "projectgroup__project__code",
+                    "projectgroup__scope",
+                )
+                .distinct()
             )
-            .distinct()
-        ):
-            groups.append(
-                f"{project_scope['projectgroup__project__code']}[{project_scope['projectgroup__scope']}]",
-            )
+        ]
 
         print(
             *(f"{key}={val}" for key, val in attrs.items()),
-            f":".join(groups),
+            f":".join(project_groups),
             sep="\t",
         )
 

--- a/onyx/accounts/management/commands/user.py
+++ b/onyx/accounts/management/commands/user.py
@@ -160,18 +160,17 @@ def list_users():
 
         groups = []
 
-        # Filter user groups to determine all distinct (code, action, scope) pairs
-        for project_action_scope in (
+        # Filter user groups to determine all distinct (code, scope) pairs
+        for project_scope in (
             user.groups.filter(projectgroup__isnull=False)
             .values(
                 "projectgroup__project__code",
-                "projectgroup__action",
                 "projectgroup__scope",
             )
             .distinct()
         ):
             groups.append(
-                f"{project_action_scope['projectgroup__project__code']}[{project_action_scope['projectgroup__action']}][{project_action_scope['projectgroup__scope']}]",
+                f"{project_scope['projectgroup__project__code']}[{project_scope['projectgroup__scope']}]",
             )
 
         print(

--- a/onyx/accounts/permissions.py
+++ b/onyx/accounts/permissions.py
@@ -1,7 +1,8 @@
 from rest_framework import permissions
 from rest_framework.request import Request
 from .exceptions import ProjectNotFound, ScopeNotFound
-from utils.functions import get_suggestions
+from utils.functions import get_suggestions, get_permission
+from data.models import Project
 
 
 class AllowAny(permissions.AllowAny):
@@ -95,65 +96,55 @@ class IsProjectApproved(permissions.BasePermission):
     """
 
     def has_permission(self, request: Request, view):
-        project = view.kwargs["code"].lower()
-        scopes = ["base"] + [
-            code.lower() for code in request.query_params.getlist("scope")
-        ]
+        # TODO: Add the project actions back as a list?
+        # Get the project
+        try:
+            project = Project.objects.get(code__iexact=view.kwargs["code"])
+        except Project.DoesNotExist:
+            suggestions = get_suggestions(
+                view.kwargs["code"],
+                options=(
+                    request.user.groups.values_list(
+                        "projectgroup__project__code", flat=True
+                    ).distinct()
+                ),
+                n=1,
+                message_prefix="Project not found.",
+            )
+            raise ProjectNotFound(suggestions)
 
-        for scope in scopes:
-            # Check the user's permission to perform action on the project + scope
-            if not request.user.groups.filter(
-                projectgroup__project__code=project,
-                projectgroup__action=view.project_action,
-                projectgroup__scope=scope,
-            ).exists():
-                # If the user doesn't have permission, check they can view the project + scope
-                if (
-                    view.project_action != "view"
-                    and request.user.groups.filter(
-                        projectgroup__project__code=project,
-                        projectgroup__action="view",
-                        projectgroup__scope=scope,
-                    ).exists()
-                ):
-                    # If the user has permission to view the project + scope, then tell them they require permission for the action
-                    self.message = f"You do not have permission to perform action '{view.project_action}' for scope '{scope}' on project '{project}'."
-                    return False
-                else:
-                    # If they do not have permission to view the project + scope, tell them the project / scope doesn't exist
-                    if scope == "base":
-                        suggestions = get_suggestions(
-                            project,
-                            options=(
-                                request.user.groups.filter(
-                                    projectgroup__action=view.project_action,
-                                    projectgroup__scope=scope,
-                                )
-                                .values_list("projectgroup__project__code", flat=True)
-                                .distinct()
-                            ),
-                            n=1,
-                            message_prefix="Project not found.",
-                        )
+        # Check the user's permission to access the project
+        project_access_permission = get_permission(
+            app_label=project.content_type.app_label,
+            action="access",
+            code=project.code,
+        )
 
-                        raise ProjectNotFound(suggestions)
-                    else:
-                        suggestions = get_suggestions(
-                            scope,
-                            options=(
-                                request.user.groups.filter(
-                                    projectgroup__project__code=project,
-                                    projectgroup__action=view.project_action,
-                                )
-                                .values_list("projectgroup__scope", flat=True)
-                                .distinct()
-                            ),
-                            n=1,
-                            message_prefix="Scope not found.",
-                        )
+        if not request.user.has_perm(project_access_permission):
+            suggestions = get_suggestions(
+                view.kwargs["code"],
+                options=(
+                    request.user.groups.values_list(
+                        "projectgroup__project__code", flat=True
+                    ).distinct()
+                ),
+                n=1,
+                message_prefix="Project not found.",
+            )
+            raise ProjectNotFound(suggestions)
 
-                        raise ScopeNotFound(suggestions)
+        # Check the user's permission to perform action on the project
+        project_action_permission = get_permission(
+            app_label=project.content_type.app_label,
+            action=view.project_action,
+            code=project.code,
+        )
 
+        if not request.user.has_perm(project_action_permission):
+            self.message = f"You do not have permission to perform action '{view.project_action}' on project '{project.code}'."
+            return False
+
+        # If the user has permission to access and perform action on the project, then they have permission
         return True
 
 

--- a/onyx/accounts/views.py
+++ b/onyx/accounts/views.py
@@ -127,15 +127,16 @@ class ProjectUserView(KnoxLoginView):
     permission_classes = Admin
 
     def post(self, request, *args, **kwargs):
+        # TODO: Change method back to POST
         raise exceptions.MethodNotAllowed(self.request.method)
 
     def get(self, request, code, site_code, username):
-        # Get the base view group for the requested project
+        # Get the analyst group for the requested project
+        # TODO: This is ad-hoc for CLIMB-TRE purposes and needs generalising
         try:
-            view_group = Group.objects.get(
+            analyst_group = Group.objects.get(
                 projectgroup__project__code=code,
-                projectgroup__action="view",
-                projectgroup__scope="base",
+                projectgroup__scope="analyst",
             )
         except Group.DoesNotExist:
             raise ProjectNotFound
@@ -168,7 +169,8 @@ class ProjectUserView(KnoxLoginView):
             user.set_unusable_password()
             user.save()
 
-        user.groups.add(view_group)
+        # Add the user to the analyst group
+        user.groups.add(analyst_group)
 
         request.user = user
         return super().post(request)

--- a/onyx/data/actions.py
+++ b/onyx/data/actions.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class Actions(Enum):
+    GET = "get"
+    LIST = "list"
+    FILTER = "filter"
+    IDENTIFY = "identify"
+    ADD = "add"
+    CHANGE = "change"
+    DELETE = "delete"

--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -9,7 +9,7 @@ from utils.fields import (
     ChoiceField,
     YearMonthField,
 )
-from utils.functions import get_suggestions
+from utils.functions import get_suggestions, get_permission
 from accounts.models import User
 from .models import Choice, Project, ProjectRecord
 from .types import OnyxType, ALL_LOOKUPS
@@ -135,7 +135,7 @@ class FieldHandler:
     - Checks whether the user has permission to action on the resolved fields.
     """
 
-    __slots__ = "code", "model", "app_label", "action", "user", "user_fields"
+    __slots__ = "code", "model", "app_label", "action", "user", "fields"
 
     def __init__(
         self,
@@ -151,65 +151,36 @@ class FieldHandler:
         self.app_label = project.content_type.app_label
         self.action = action
         self.user = user
-        self.user_fields = None
+        self.fields = None
 
     def get_fields(
         self,
-        scopes: list[str] | None = None,
     ) -> list[str]:
         """
-        Get fields that can be actioned on within provided scopes.
-
-        Args:
-            scopes: The scopes to include fields from. If None, only the base scope is used.
+        Get all fields that can be actioned on.
 
         Returns:
-            The list of fields that can be actioned on within provided scopes.
+            The list of fields that the user can action on.
         """
 
-        if not scopes:
-            scopes = ["base"]
+        if not self.fields:
+            fields = []
 
-        groups = Group.objects.filter(
-            projectgroup__project__code=self.code,
-            projectgroup__action=self.action,
-            projectgroup__scope__in=scopes,
-        )
+            for permission in self.user.get_all_permissions():
+                _, codename = permission.split(".")
+                action_project, _, field_path = codename.partition("__")
 
-        permissions = [
-            permission for group in groups for permission in group.permissions.all()
-        ]
+                if not field_path:
+                    continue
 
-        fields = [permission.codename.partition("__")[2] for permission in permissions]
+                action, project = action_project.split("_")
 
-        return fields
+                if action == self.action and project == self.code:
+                    fields.append(field_path)
 
-    def get_user_fields(
-        self,
-    ) -> list[str]:
-        """
-        Get all fields that the user can action on within the project.
+            self.fields = fields
 
-        Returns:
-            The list of fields that the user can action on within the project.
-        """
-
-        if not self.user_fields:
-            groups = self.user.groups.filter(
-                projectgroup__project__code=self.code,
-                projectgroup__action=self.action,
-            )
-
-            permissions = [
-                permission for group in groups for permission in group.permissions.all()
-            ]
-
-            fields = [
-                permission.codename.partition("__")[2] for permission in permissions
-            ]
-            self.user_fields = fields
-
-        return self.user_fields
+        return self.fields
 
     def unknown_field_suggestions(self, field) -> str:
         """
@@ -226,7 +197,7 @@ class FieldHandler:
 
         suggestions = get_suggestions(
             field,
-            options=self.get_user_fields(),
+            options=self.get_fields(),
             message_prefix="This field is unknown.",
         )
 
@@ -240,28 +211,33 @@ class FieldHandler:
             onyx_field: The `OnyxField` object to check user permissions for.
         """
 
-        # Check whether the user can perform the action on the field
         # TODO: Refactor this to use model name rather than project code (more granular permissions).
-        field_action_permission = (
-            f"{self.app_label}.{self.action}_{self.code}__{onyx_field.field_path}"
+
+        # Check the user's permission to access the field
+        # If the user does not have permission, tell them it is unknown
+        field_access_permission = get_permission(
+            app_label=self.app_label,
+            action="access",
+            code=self.code,
+            field=onyx_field.field_path,
+        )
+
+        if not self.user.has_perm(field_access_permission):
+            raise exceptions.ValidationError(
+                self.unknown_field_suggestions(onyx_field.field_path)
+            )
+
+        # Check the user's permission to perform action on the field
+        # If the user does not have permission, tell them it is not allowed
+        field_action_permission = get_permission(
+            app_label=self.app_label,
+            action=self.action,
+            code=self.code,
+            field=onyx_field.field_path,
         )
 
         if not self.user.has_perm(field_action_permission):
-            # If they do not have permission, check whether they can view the field
-            field_view_permission = (
-                f"{self.app_label}.view_{self.code}__{onyx_field.field_path}"
-            )
-
-            if self.action != "view" and self.user.has_perm(field_view_permission):
-                # If the user has permission to view the field, return the action permission required
-                raise exceptions.ValidationError(
-                    f"You cannot {self.action} this field."
-                )
-            else:
-                # If the user does not have permission, tell them it is unknown
-                raise exceptions.ValidationError(
-                    self.unknown_field_suggestions(onyx_field.field_path)
-                )
+            raise exceptions.ValidationError(f"You cannot {self.action} this field.")
 
     def resolve_field(
         self,
@@ -376,6 +352,7 @@ class FieldHandler:
 def generate_fields_spec(
     fields_dict: dict,
     onyx_fields: dict[str, OnyxField],
+    actions_map: dict[str, str],
     prefix: str | None = None,
 ) -> dict[str, Any]:
     """
@@ -404,12 +381,14 @@ def generate_fields_spec(
             "description": onyx_fields[field_path].description,
             "type": onyx_type.label,
             "required": onyx_fields[field_path].required,
+            "actions": actions_map[field_path],
         }
 
         if onyx_type == OnyxType.RELATION:
             generate_fields_spec(
                 fields_dict=nested,
                 onyx_fields=onyx_fields,
+                actions_map=actions_map,
                 prefix=field_path,
             )
             field_dict["fields"] = nested

--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -8,7 +8,7 @@ from utils.fields import (
     ChoiceField,
     YearMonthField,
 )
-from utils.functions import get_suggestions, get_permission
+from utils.functions import get_suggestions, get_permission, parse_permission
 from accounts.models import User
 from .models import Choice, Project, ProjectRecord
 from .types import OnyxType, ALL_LOOKUPS
@@ -168,16 +168,10 @@ class FieldHandler:
             fields = []
 
             for permission in self.user.get_all_permissions():
-                _, codename = permission.split(".")
-                action_project, _, field_path = codename.partition("__")
+                _, action, project, field = parse_permission(permission)
 
-                if not field_path:
-                    continue
-
-                action, project = action_project.split("_")
-
-                if action == self.action and project == self.code:
-                    fields.append(field_path)
+                if action == self.action and project == self.code and field:
+                    fields.append(field)
 
             self.fields = fields
 

--- a/onyx/data/management/commands/project.py
+++ b/onyx/data/management/commands/project.py
@@ -233,7 +233,7 @@ class Command(base.BaseCommand):
                 self.print(
                     f"Updated project group: {self.project.code} | {projectgroup.scope}"
                 )
-            self.print(f"Actions: {" | ".join(group_actions)}")
+            self.print(f"Actions: {' | '.join(group_actions)}")
 
     def set_choices(self, choice_configs: List[ChoiceConfig]):
         """

--- a/onyx/data/management/commands/project.py
+++ b/onyx/data/management/commands/project.py
@@ -7,10 +7,14 @@ from django.contrib.contenttypes.models import ContentType
 from ...models import Project, ProjectGroup, Choice
 
 
-class GroupConfig(BaseModel):
-    action: str
-    scope: str
+class PermissionConfig(BaseModel):
+    action: str | List[str]
     fields: List[str]
+
+
+class GroupConfig(BaseModel):
+    scope: str
+    permissions: List[PermissionConfig]
 
 
 class ChoiceConfig(BaseModel):
@@ -28,7 +32,7 @@ class ProjectConfig(BaseModel):
     code: str
     name: Optional[str]
     description: Optional[str]
-    content_type: Optional[str]
+    content_type: str
     groups: Optional[List[GroupConfig]]
     choices: Optional[List[ChoiceConfig]]
     choice_constraints: Optional[List[ChoiceConstraintConfig]]
@@ -60,24 +64,21 @@ class Command(base.BaseCommand):
         Create/update the project.
         """
 
-        # If a {app}.{model} was provided, use it to get the content_type
-        # Otherwise, assume that app = data and that the model has the same name as the project
-        if project_config.content_type:
-            app, _, model = project_config.content_type.partition(".")
-        else:
-            app, model = "data", project_config.code
+        # Get the app and model from the content type
+        app, _, model = project_config.content_type.partition(".")
 
+        # Create or retrieve the project
         self.project, p_created = Project.objects.update_or_create(
             code=project_config.code,
             defaults={
                 # If no name was provided, use the code
-                "name": project_config.name
-                if project_config.name
-                else project_config.code,
+                "name": (
+                    project_config.name if project_config.name else project_config.code
+                ),
                 # If no description was provided, set as empty
-                "description": project_config.description
-                if project_config.description
-                else "",
+                "description": (
+                    project_config.description if project_config.description else ""
+                ),
                 "content_type": ContentType.objects.get(app_label=app, model=model),
             },
         )
@@ -114,8 +115,8 @@ class Command(base.BaseCommand):
 
         for group_config in group_configs:
             # Create or retrieve underlying permissions group
-            # This is based on project code, action and scope
-            name = f"{self.project.code}.{group_config.action}.{group_config.scope}"
+            # This is based on project code and scope
+            name = f"{self.project.code}.{group_config.scope}"
             group, g_created = Group.objects.get_or_create(name=name)
 
             if g_created:
@@ -125,20 +126,74 @@ class Command(base.BaseCommand):
 
             # Create or retrieve permissions for the group from the fields within the data
             permissions = []
-            for field in group_config.fields:
-                codename = f"{group_config.action}_{self.project.code}__{field}"
-                permission, p_created = Permission.objects.get_or_create(
+
+            # Permission to access project
+            access_project_codename = f"access_{self.project.code}"
+            access_project_permission, access_project_created = (
+                Permission.objects.get_or_create(
                     content_type=self.project.content_type,
-                    codename=codename,
-                    name=f"Can {group_config.action} {self.project.code}{' ' + field if field else ''}",
+                    codename=access_project_codename,
+                    name=f"Can access {self.project.code}",
                 )
-                if p_created:
-                    self.print("Created permission:", permission)
+            )
+            if access_project_created:
+                self.print("Created permission:", access_project_permission)
+            permissions.append(access_project_permission)
 
-                permissions.append(permission)
+            for permission_config in group_config.permissions:
+                if isinstance(permission_config.action, str):
+                    actions = [permission_config.action]
+                else:
+                    actions = permission_config.action
 
-            # Set permissions for the group, and print them if they exist
+                for action in actions:
+                    # Permission to action on project
+                    action_project_codename = f"{action}_{self.project.code}"
+                    action_project_permission, action_project_created = (
+                        Permission.objects.get_or_create(
+                            content_type=self.project.content_type,
+                            codename=action_project_codename,
+                            name=f"Can {action} {self.project.code}",
+                        )
+                    )
+                    if action_project_created:
+                        self.print("Created permission:", action_project_permission)
+                    permissions.append(action_project_permission)
+
+                    # Field permissions for the action
+                    for field in permission_config.fields:
+                        assert field, "Field cannot be empty."
+
+                        # Permission to access field
+                        access_field_codename = f"access_{self.project.code}__{field}"
+                        access_field_permission, access_field_created = (
+                            Permission.objects.get_or_create(
+                                content_type=self.project.content_type,
+                                codename=access_field_codename,
+                                name=f"Can access {self.project.code} {field}",
+                            )
+                        )
+                        if access_field_created:
+                            self.print("Created permission:", access_field_permission)
+                        permissions.append(access_field_permission)
+
+                        # Permission to action on field
+                        action_field_codename = f"{action}_{self.project.code}__{field}"
+                        action_field_permission, action_field_created = (
+                            Permission.objects.get_or_create(
+                                content_type=self.project.content_type,
+                                codename=action_field_codename,
+                                name=f"Can {action} {self.project.code} {field}",
+                            )
+                        )
+                        if action_field_created:
+                            self.print("Created permission:", action_field_permission)
+                        permissions.append(action_field_permission)
+
+            # Set permissions for the group
             group.permissions.set(permissions)
+
+            # Print permissions for the group
             if permissions:
                 self.print(f"Permissions for {name}:")
                 for perm in group.permissions.all():
@@ -147,21 +202,21 @@ class Command(base.BaseCommand):
                 self.print(f"Group {name} has no permissions.")
 
             # Add the group to the groups structure
-            groups[(group_config.action, group_config.scope)] = group
+            groups[group_config.scope] = group
 
-        # Create/update the corresponding project group for each group
-        for (action, scope), group in groups.items():
+        # Create/update the corresponding projectgroup for each group
+        for scope, group in groups.items():
             projectgroup, pg_created = ProjectGroup.objects.update_or_create(
                 group=group,
-                defaults={"project": self.project, "action": action, "scope": scope},
+                defaults={"project": self.project, "scope": scope},
             )
             if pg_created:
                 self.print(
-                    f"Created project group: {self.project.code} | {projectgroup.action} | {projectgroup.scope}"
+                    f"Created project group: {self.project.code} | {projectgroup.scope}"
                 )
             else:
                 self.print(
-                    f"Updated project group: {self.project.code} | {projectgroup.action} | {projectgroup.scope}"
+                    f"Updated project group: {self.project.code} | {projectgroup.scope}"
                 )
 
     def set_choices(self, choice_configs: List[ChoiceConfig]):

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -28,6 +28,7 @@ class ProjectGroup(models.Model):
     )
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
     scope = LowerCharField(max_length=50)
+    actions = models.TextField(blank=True)
 
     class Meta:
         constraints = [

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -20,10 +20,6 @@ class Project(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
 
 
-# TODO: Finalise and test
-# This is just on the brink of exactly what I was after: a singular model for linking project, action, scope, group.
-# Assuming speed not a problem, from this we can search groups by scope, action, project, without needing a group naming convention
-# We do have the issue though that deleting a project will not cascade delete the groups, but I guess this is not an issue (?)
 class ProjectGroup(models.Model):
     group = models.OneToOneField(
         Group,
@@ -31,28 +27,13 @@ class ProjectGroup(models.Model):
         primary_key=True,
     )
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
-    action = LowerCharField(
-        max_length=10,
-        choices=[
-            (x, x)
-            for x in [
-                "add",
-                "view",
-                "filter",
-                "summarise",
-                "identify",
-                "change",
-                "delete",
-            ]
-        ],
-    )
-    scope = LowerCharField(max_length=50, default="base")
+    scope = LowerCharField(max_length=50)
 
     class Meta:
         constraints = [
             unique_together(
                 model_name="projectgroup",
-                fields=["project", "scope", "action"],
+                fields=["project", "scope"],
             ),
         ]
 

--- a/onyx/data/serializers/__init__.py
+++ b/onyx/data/serializers/__init__.py
@@ -3,6 +3,7 @@ import importlib, inspect
 from django.db.models import Model
 from . import projects
 from .serializers import (
+    BaseRecordSerializer,
     ProjectRecordSerializer,
     SerializerNode,
     SummarySerializer,

--- a/onyx/data/serializers/__init__.py
+++ b/onyx/data/serializers/__init__.py
@@ -3,7 +3,6 @@ import importlib, inspect
 from django.db.models import Model
 from . import projects
 from .serializers import (
-    BaseRecordSerializer,
     ProjectRecordSerializer,
     SerializerNode,
     SummarySerializer,

--- a/onyx/data/tests/project.json
+++ b/onyx/data/tests/project.json
@@ -38,8 +38,8 @@
                 {
                     "action": [
                         "get",
-                        "filter",
-                        "view"
+                        "list",
+                        "filter"
                     ],
                     "fields": [
                         "climb_id",

--- a/onyx/data/tests/project.json
+++ b/onyx/data/tests/project.json
@@ -5,104 +5,108 @@
     "content_type": "data.testmodel",
     "groups": [
         {
-            "action": "add",
-            "scope": "base",
-            "fields": [
-                "sample_id",
-                "run_name",
-                "collection_month",
-                "received_month",
-                "char_max_length_20",
-                "text_option_1",
-                "text_option_2",
-                "submission_date",
-                "country",
-                "region",
-                "concern",
-                "tests",
-                "score",
-                "start",
-                "end",
-                "records",
-                "records__test_id",
-                "records__test_pass",
-                "records__test_start",
-                "records__test_end",
-                "records__score_a",
-                "records__score_b",
-                "records__score_c"
+            "scope": "test",
+            "permissions": [
+                {
+                    "action": "add",
+                    "fields": [
+                        "sample_id",
+                        "run_name",
+                        "collection_month",
+                        "received_month",
+                        "char_max_length_20",
+                        "text_option_1",
+                        "text_option_2",
+                        "submission_date",
+                        "country",
+                        "region",
+                        "concern",
+                        "tests",
+                        "score",
+                        "start",
+                        "end",
+                        "records",
+                        "records__test_id",
+                        "records__test_pass",
+                        "records__test_start",
+                        "records__test_end",
+                        "records__score_a",
+                        "records__score_b",
+                        "records__score_c"
+                    ]
+                },
+                {
+                    "action": [
+                        "get",
+                        "filter",
+                        "view"
+                    ],
+                    "fields": [
+                        "climb_id",
+                        "published_date",
+                        "sample_id",
+                        "run_name",
+                        "collection_month",
+                        "received_month",
+                        "char_max_length_20",
+                        "text_option_1",
+                        "text_option_2",
+                        "submission_date",
+                        "country",
+                        "region",
+                        "concern",
+                        "tests",
+                        "score",
+                        "start",
+                        "end",
+                        "records",
+                        "records__test_id",
+                        "records__test_pass",
+                        "records__test_start",
+                        "records__test_end",
+                        "records__score_a",
+                        "records__score_b",
+                        "records__score_c"
+                    ]
+                },
+                {
+                    "action": "identify",
+                    "fields": [
+                        "sample_id",
+                        "run_name"
+                    ]
+                },
+                {
+                    "action": "change",
+                    "fields": [
+                        "collection_month",
+                        "received_month",
+                        "char_max_length_20",
+                        "text_option_1",
+                        "text_option_2",
+                        "submission_date",
+                        "country",
+                        "region",
+                        "concern",
+                        "tests",
+                        "score",
+                        "start",
+                        "end",
+                        "records",
+                        "records__test_id",
+                        "records__test_pass",
+                        "records__test_start",
+                        "records__test_end",
+                        "records__score_a",
+                        "records__score_b",
+                        "records__score_c"
+                    ]
+                },
+                {
+                    "action": "delete",
+                    "fields": []
+                }
             ]
-        },
-        {
-            "action": "view",
-            "scope": "base",
-            "fields": [
-                "climb_id",
-                "published_date",
-                "sample_id",
-                "run_name",
-                "collection_month",
-                "received_month",
-                "char_max_length_20",
-                "text_option_1",
-                "text_option_2",
-                "submission_date",
-                "country",
-                "region",
-                "concern",
-                "tests",
-                "score",
-                "start",
-                "end",
-                "records",
-                "records__test_id",
-                "records__test_pass",
-                "records__test_start",
-                "records__test_end",
-                "records__score_a",
-                "records__score_b",
-                "records__score_c"
-            ]
-        },
-        {
-            "action": "change",
-            "scope": "base",
-            "fields": [
-                "collection_month",
-                "received_month",
-                "char_max_length_20",
-                "text_option_1",
-                "text_option_2",
-                "submission_date",
-                "country",
-                "region",
-                "concern",
-                "tests",
-                "score",
-                "start",
-                "end",
-                "records",
-                "records__test_id",
-                "records__test_pass",
-                "records__test_start",
-                "records__test_end",
-                "records__score_a",
-                "records__score_b",
-                "records__score_c"
-            ]
-        },
-        {
-            "action": "identify",
-            "scope": "base",
-            "fields": [
-                "sample_id",
-                "run_name"
-            ]
-        },
-        {
-            "action": "delete",
-            "scope": "base",
-            "fields": []
         }
     ],
     "choices": [

--- a/onyx/data/tests/views/test_choices.py
+++ b/onyx/data/tests/views/test_choices.py
@@ -14,7 +14,7 @@ class TestChoicesView(OnyxTestCase):
             "data.project.choices", kwargs={"code": "test", "field": field}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -58,7 +58,7 @@ class TestCreateView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.add.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -17,17 +17,14 @@ class TestDeleteView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.delete.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.climb_id = response.json()["data"]["climb_id"]
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
 
     def test_basic(self):
         """

--- a/onyx/data/tests/views/test_fields.py
+++ b/onyx/data/tests/views/test_fields.py
@@ -12,7 +12,7 @@ class TestFieldsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project.fields", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -20,14 +20,11 @@ class TestFilterView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         for payload in generate_test_data():
             response = self.client.post(self.endpoint, data=payload)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
 
     def assertEqualClimbIDs(self, records, qs, allow_empty=False):
         """

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -16,17 +16,14 @@ class TestGetView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.climb_id = response.json()["data"]["climb_id"]
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
 
     def test_basic(self):
         """

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data, _test_record

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -16,10 +16,8 @@ class TestIdentifyView(OnyxTestCase):
             "data.project.identify", kwargs={"code": "test", "field": field}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.identify.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         test_record = next(iter(generate_test_data(n=1)))
         self.input_sample_id = test_record["sample_id"]
         self.input_run_name = test_record["run_name"]
@@ -30,7 +28,6 @@ class TestIdentifyView(OnyxTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.output_sample_id = response.json()["data"]["sample_id"]
         self.output_run_name = response.json()["data"]["run_name"]
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
 
     def test_basic(self):
         """

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data

--- a/onyx/data/tests/views/test_lookups.py
+++ b/onyx/data/tests/views/test_lookups.py
@@ -13,7 +13,7 @@ class TestLookupsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project.lookups", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -1,6 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase
+from ...actions import Actions
 
 
 class TestProjectsView(OnyxTestCase):
@@ -24,5 +25,11 @@ class TestProjectsView(OnyxTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["data"],
-            [{"project": "test", "scope": "test"}],
+            [
+                {
+                    "project": "test",
+                    "scope": "test",
+                    "actions": [action.value for action in Actions],
+                }
+            ],
         )

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -12,7 +12,7 @@ class TestProjectsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.projects")
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.view.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
     def test_basic(self):
@@ -24,5 +24,5 @@ class TestProjectsView(OnyxTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["data"],
-            [{"project": "test", "action": "view", "scope": "base"}],
+            [{"project": "test", "scope": "test"}],
         )

--- a/onyx/data/tests/views/test_query.py
+++ b/onyx/data/tests/views/test_query.py
@@ -16,11 +16,7 @@ class TestQueryView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser",
-            roles=["is_staff"],
-            groups=[
-                "test.view.base",
-            ],
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
 
         self.user.groups.add(Group.objects.get(name="test.add.base"))

--- a/onyx/data/tests/views/test_query.py
+++ b/onyx/data/tests/views/test_query.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data
@@ -14,15 +13,12 @@ class TestQueryView(OnyxTestCase):
         """
 
         super().setUp()
-        self.endpoint = reverse("data.project", kwargs={"code": "test"})
+        self.endpoint = reverse("data.project.query", kwargs={"code": "test"})
         self.user = self.setup_user(
             "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         for payload in generate_test_data():
-            response = self.client.post(self.endpoint, data=payload)
+            response = self.client.post(
+                reverse("data.project", kwargs={"code": "test"}), data=payload
+            )
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
-
-        self.endpoint = reverse("data.project.query", kwargs={"code": "test"})

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -17,17 +17,14 @@ class TestUpdateView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.change.base"]
+            "testuser", roles=["is_staff"], groups=["test.test"]
         )
-
-        self.user.groups.add(Group.objects.get(name="test.add.base"))
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.climb_id = response.json()["data"]["climb_id"]
-        self.user.groups.remove(Group.objects.get(name="test.add.base"))
 
     def test_basic(self):
         """

--- a/onyx/utils/functions.py
+++ b/onyx/utils/functions.py
@@ -38,6 +38,30 @@ def get_suggestions(
     return message
 
 
+def get_permission(
+    app_label: str,
+    action: str,
+    code: str,
+    field: str | None = None,
+):
+    """
+    Returns a permission string for a given `app_label`, `action`, `code`, and `field`.
+
+    The permission string is in the format:
+
+    `<app_label>.<action>_<code>`
+
+    If `field` is provided, the permission string will be in the format:
+
+    `<app_label>.<action>_<code>__<field>`
+    """
+
+    if field:
+        return f"{app_label}.{action}_{code}__{field}"
+    else:
+        return f"{app_label}.{action}_{code}"
+
+
 def strtobool(val):
     """
     Convert a string representation of truth to True or False.

--- a/onyx/utils/functions.py
+++ b/onyx/utils/functions.py
@@ -62,6 +62,20 @@ def get_permission(
         return f"{app_label}.{action}_{code}"
 
 
+def parse_permission(permission: str) -> tuple[str, str, str, str]:
+    """
+    Parses a permission string into its components.
+
+    Returns a tuple containing the `app_label`, `action`, `code`, and `field`.
+    """
+
+    app_label, codename = permission.split(".")
+    action_project, _, field_path = codename.partition("__")
+    action, project = action_project.split("_")
+
+    return app_label, action, project, field_path
+
+
 def strtobool(val):
     """
     Convert a string representation of truth to True or False.


### PR DESCRIPTION
### Permissions refactor
Django provides a permissions system using the `Group` and `Permission` models. These enable multiple permissions to be assigned to a group, and then multiple groups to be assigned to a user.

Onyx uses groups to organise user project/field permissions. Previously, Onyx organised groups by the following naming convention:
`project.action.scope`
where permissions on fields were grouped by project, action (e.g. add, view, etc) and scope (e.g. base, admin). This system was rapidly growing unwieldy, due to many groups appearing as the number of actions was sought to increase (more granular actions are needed to control what fields users can filter/view on). It was also difficult to reason with, e.g. admin accounts needed granting both the 'base' scope and 'admin' scopes for an action in order to do anything, users had to provide scopes in order to view certain fields, and there was no clear idea what should be the 'default' fields returned to a user for a given action.

This PR overhauls those issues by introducing a new naming convention for the groups:
`project.scope`
where permissions are now grouped by project and scope, where scope now refers more clearly to a 'role'. For example, we can now define 'admin', 'analyst' and 'uploader' roles, have one group for each of these, and assign all the allowed actions into these groups.

**TL:DR: groups now contain all the allowed actions for a given scope, or 'role', rather than having individual groups for each action.**

With this, we now follow a very simple convention for what is returned on get/filter/query/fields:

**The fields returned to a user are all the fields the user is allowed to see for that action.**

So users cannot control additional fields being returned via scopes anymore, but they can still include/exclude fields.
And on the topic of actions, new ones have been introduced, and some have been removed. The new set of actions is:
- Get: The user can get a single instance of the project/field
- List: The user can list any number of instances of the project/field at once
- Filter: The user can filter/summarise/query on the project/field
- Identify: The user can match an anonymised value to its identifier on the project/field
- Add: The user can add on the project/field
- Change: The user can update on the project/field
- Delete: The user can delete on the project
- Access: The user has any of the above actions on the project/field

So the project and field permission checks now follows a very simple algorithm:
1. No access permission on the project/field = the project/field is not found
2. The specific action is not available on the project/field = the project/field is denied

Other related details:
- The `project` management command now takes an updated group json structure, with multiple actions per group. For each action and field added, an additional 'access' permission is added which indicates the user can 'see' the project/field.
- `ProjectUserView` now grants users the 'analyst' group for a project, rather than the 'view' group (likely a temporary change)
- `get_permission` and `parse_permission` functions for retrieving permissions
- `FieldHandler.get_user_fields()` removed, redundant now that scopes are out of user control. `FieldHandler.get_fields()` now just returns the fields the user can action on.
- `ProjectGroup` model now stores `actions` string rather than singular `action`
- Tests updated to match new group naming conventions

### Field spec generation improvements
The `generate_fields_spec` function now takes `serializer` and `actions_map` arguments. This enables the following improvements to the fields spec: 
- The user's available actions for each field are displayed to them. 
- Any serializer validation can be displayed, starting with `optional_value_group` restrictions. 
- Fields in the spec are now ordered according to their order in the serializer, rather than alphabetically. 

### Extra details:
- Match statement used on ProjectRecordsViewSet to get allowed request methods


