### PR TITLE
Published flag, refactored constraints, updated queryset handling of published/suppressed/restricted data

### DIFF
--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -1,5 +1,6 @@
 from typing import Any
 import uuid
+from datetime import datetime
 from secrets import token_hex
 from django.db import models
 from django.contrib.auth.models import Group
@@ -119,17 +120,21 @@ class ProjectRecord(BaseRecord):
     climb_id = UpperCharField(
         max_length=12,
         unique=True,
-        help_text="Unique identifier for a project record. Set by Onyx.",
+        help_text="Unique identifier for a project record in Onyx.",
+    )
+    is_published = models.BooleanField(
+        default=True,
+        help_text="Indicator for whether a project record has been published.",
     )
     published_date = models.DateField(
-        auto_now_add=True,
-        help_text="The date the project record was published. Set by Onyx.",
+        null=True,
+        help_text="The date the project record was published in Onyx.",
     )
-    suppressed = models.BooleanField(
+    is_suppressed = models.BooleanField(
         default=False,
         help_text="Indicator for whether a project record has been hidden from users.",
     )
-    site_restricted = models.BooleanField(
+    is_site_restricted = models.BooleanField(
         default=False,
         help_text="Indicator for whether a project record has been hidden from users not within the record's site.",
     )
@@ -141,6 +146,9 @@ class ProjectRecord(BaseRecord):
         if not self.pk:
             climb_id = ClimbID.objects.create()
             self.climb_id = climb_id.climb_id
+
+        if self.published_date is None and self.is_published:
+            self.published_date = datetime.today().date()
 
         super().save(*args, **kwargs)
 

--- a/onyx/data/models/models.py
+++ b/onyx/data/models/models.py
@@ -34,7 +34,6 @@ class ProjectGroup(models.Model):
     class Meta:
         constraints = [
             unique_together(
-                model_name="projectgroup",
                 fields=["project", "scope"],
             ),
         ]
@@ -56,7 +55,6 @@ class Choice(models.Model):
         ]
         constraints = [
             unique_together(
-                model_name="choice",
                 fields=["project", "field", "choice"],
             ),
         ]

--- a/onyx/data/models/projects/test.py
+++ b/onyx/data/models/projects/test.py
@@ -7,6 +7,7 @@ from utils.constraints import (
     ordering,
     non_futures,
     conditional_required,
+    conditional_value_required,
 )
 
 
@@ -63,9 +64,10 @@ class BaseTestModel(ProjectRecord):
         indexes = [
             models.Index(fields=["created"]),
             models.Index(fields=["climb_id"]),
+            models.Index(fields=["is_published"]),
             models.Index(fields=["published_date"]),
-            models.Index(fields=["suppressed"]),
-            models.Index(fields=["site_restricted"]),
+            models.Index(fields=["is_suppressed"]),
+            models.Index(fields=["is_site_restricted"]),
             models.Index(fields=["sample_id", "run_name"]),
             models.Index(fields=["sample_id"]),
             models.Index(fields=["run_name"]),
@@ -101,6 +103,12 @@ class BaseTestModel(ProjectRecord):
                 model_name="basetestmodel",
                 field="region",
                 required=["country"],
+            ),
+            conditional_value_required(
+                model_name="mscape",
+                field="is_published",
+                value=True,
+                required=["published_date"],
             ),
         ]
 

--- a/onyx/data/models/projects/test.py
+++ b/onyx/data/models/projects/test.py
@@ -58,6 +58,7 @@ class BaseTestModel(ProjectRecord):
     score = models.FloatField(null=True)
     start = models.IntegerField()
     end = models.IntegerField()
+    required_when_published = models.TextField(blank=True)
 
     class Meta:
         default_permissions = []
@@ -76,39 +77,36 @@ class BaseTestModel(ProjectRecord):
         ]
         constraints = [
             unique_together(
-                model_name="basetestmodel",
                 fields=["sample_id", "run_name"],
             ),
             optional_value_group(
-                model_name="basetestmodel",
                 fields=["collection_month", "received_month"],
             ),
             optional_value_group(
-                model_name="basetestmodel",
                 fields=["text_option_1", "text_option_2"],
             ),
             ordering(
-                model_name="basetestmodel",
                 fields=("collection_month", "received_month"),
             ),
             ordering(
-                model_name="basetestmodel",
                 fields=("start", "end"),
             ),
             non_futures(
-                model_name="basetestmodel",
                 fields=["collection_month", "received_month", "submission_date"],
             ),
             conditional_required(
-                model_name="basetestmodel",
                 field="region",
                 required=["country"],
             ),
             conditional_value_required(
-                model_name="mscape",
                 field="is_published",
                 value=True,
                 required=["published_date"],
+            ),
+            conditional_value_required(
+                field="is_published",
+                value=True,
+                required=["required_when_published"],
             ),
         ]
 
@@ -129,6 +127,7 @@ class TestModelRecord(BaseRecord):
     score_a = models.FloatField(null=True)
     score_b = models.FloatField(null=True)
     score_c = models.FloatField(null=True)
+    test_result = models.TextField(blank=True)
 
     class Meta:
         default_permissions = []
@@ -138,20 +137,21 @@ class TestModelRecord(BaseRecord):
         ]
         constraints = [
             unique_together(
-                model_name="testmodelrecord",
                 fields=["link", "test_id"],
             ),
             optional_value_group(
-                model_name="testmodelrecord",
                 fields=["score_a", "score_b"],
             ),
             ordering(
-                model_name="testmodelrecord",
                 fields=("test_start", "test_end"),
             ),
             conditional_required(
-                model_name="testmodelrecord",
                 field="score_c",
                 required=["score_a", "score_b"],
+            ),
+            conditional_value_required(
+                field="test_pass",
+                value=True,
+                required=["test_result"],
             ),
         ]

--- a/onyx/data/serializers/projects/test.py
+++ b/onyx/data/serializers/projects/test.py
@@ -106,7 +106,7 @@ class TestModelSerializer(BaseTestModelSerializer):
     class Meta:
         model = TestModel
         fields = BaseTestModelSerializer.Meta.fields
-        # NOTE: Just like fields, validators must be inherited
+        # NOTE: Just like fields, validators must be inherited, IF they exist in the parent class.
         validators = BaseTestModelSerializer.Meta.validators
 
     class OnyxMeta(BaseTestModelSerializer.OnyxMeta):

--- a/onyx/data/serializers/projects/test.py
+++ b/onyx/data/serializers/projects/test.py
@@ -24,6 +24,7 @@ class TestModelRecordSerializer(BaseRecordSerializer):
             "score_a",
             "score_b",
             "score_c",
+            "test_result",
         ]
 
     class OnyxMeta(BaseRecordSerializer.OnyxMeta):
@@ -37,6 +38,10 @@ class TestModelRecordSerializer(BaseRecordSerializer):
         conditional_required = BaseRecordSerializer.OnyxMeta.conditional_required | {
             "score_c": ["score_a", "score_b"]
         }
+        conditional_value_required = (
+            BaseRecordSerializer.OnyxMeta.conditional_value_required
+            | {("test_pass", True, None): ["test_result"]}
+        )
 
 
 class BaseTestModelSerializer(ProjectRecordSerializer):
@@ -65,6 +70,7 @@ class BaseTestModelSerializer(ProjectRecordSerializer):
             "score",
             "start",
             "end",
+            "required_when_published",
         ]
         validators = [
             OnyxUniqueTogetherValidator(
@@ -96,6 +102,14 @@ class BaseTestModelSerializer(ProjectRecordSerializer):
         conditional_required = ProjectRecordSerializer.OnyxMeta.conditional_required | {
             "region": ["country"]
         }
+        conditional_value_required = (
+            ProjectRecordSerializer.OnyxMeta.conditional_value_required
+            | {
+                ("is_published", True, True): [
+                    "required_when_published",
+                ]
+            }
+        )
         action_success_fields = (
             ProjectRecordSerializer.OnyxMeta.action_success_fields
             + ["sample_id", "run_name"]

--- a/onyx/data/tests/project.json
+++ b/onyx/data/tests/project.json
@@ -5,11 +5,12 @@
     "content_type": "data.testmodel",
     "groups": [
         {
-            "scope": "test",
+            "scope": "admin",
             "permissions": [
                 {
                     "action": "add",
                     "fields": [
+                        "is_published",
                         "sample_id",
                         "run_name",
                         "collection_month",
@@ -25,6 +26,7 @@
                         "score",
                         "start",
                         "end",
+                        "required_when_published",
                         "records",
                         "records__test_id",
                         "records__test_pass",
@@ -32,7 +34,8 @@
                         "records__test_end",
                         "records__score_a",
                         "records__score_b",
-                        "records__score_c"
+                        "records__score_c",
+                        "records__test_result"
                     ]
                 },
                 {
@@ -43,6 +46,7 @@
                     ],
                     "fields": [
                         "climb_id",
+                        "is_published",
                         "published_date",
                         "sample_id",
                         "run_name",
@@ -59,6 +63,7 @@
                         "score",
                         "start",
                         "end",
+                        "required_when_published",
                         "records",
                         "records__test_id",
                         "records__test_pass",
@@ -66,7 +71,8 @@
                         "records__test_end",
                         "records__score_a",
                         "records__score_b",
-                        "records__score_c"
+                        "records__score_c",
+                        "records__test_result"
                     ]
                 },
                 {
@@ -79,6 +85,7 @@
                 {
                     "action": "change",
                     "fields": [
+                        "is_published",
                         "collection_month",
                         "received_month",
                         "char_max_length_20",
@@ -92,6 +99,7 @@
                         "score",
                         "start",
                         "end",
+                        "required_when_published",
                         "records",
                         "records__test_id",
                         "records__test_pass",
@@ -99,7 +107,8 @@
                         "records__test_end",
                         "records__score_a",
                         "records__score_b",
-                        "records__score_c"
+                        "records__score_c",
+                        "records__test_result"
                     ]
                 },
                 {

--- a/onyx/data/tests/utils.py
+++ b/onyx/data/tests/utils.py
@@ -51,7 +51,7 @@ class OnyxTestCase(APITestCase):
         return user
 
 
-def generate_test_data(n=100):
+def generate_test_data(n: int = 100):
     """
     Generate test data.
     """
@@ -108,7 +108,7 @@ def generate_test_data(n=100):
     return data
 
 
-def _test_record(self, payload, instance, created=False):
+def _test_record(self, payload, instance, created: bool = False):
     """
     Test that a payload's values match an instance.
     """
@@ -117,16 +117,23 @@ def _test_record(self, payload, instance, created=False):
     if not created:
         self.assertEqual(payload.get("climb_id", ""), instance.climb_id)
         self.assertEqual(
-            payload.get("published_date"), instance.published_date.strftime("%Y-%m-%d")
+            payload.get("published_date"),
+            (
+                instance.published_date.strftime("%Y-%m-%d")
+                if instance.published_date
+                else None
+            ),
         )
 
     self.assertEqual(payload.get("sample_id", ""), instance.sample_id)
     self.assertEqual(payload.get("run_name", ""), instance.run_name)
     self.assertEqual(
         payload.get("collection_month"),
-        instance.collection_month.strftime("%Y-%m")
-        if instance.collection_month
-        else None,
+        (
+            instance.collection_month.strftime("%Y-%m")
+            if instance.collection_month
+            else None
+        ),
     )
     self.assertEqual(
         payload.get("received_month"),
@@ -137,9 +144,11 @@ def _test_record(self, payload, instance, created=False):
     self.assertEqual(payload.get("text_option_2", ""), instance.text_option_2)
     self.assertEqual(
         payload.get("submission_date"),
-        instance.submission_date.strftime("%Y-%m-%d")
-        if instance.submission_date
-        else None,
+        (
+            instance.submission_date.strftime("%Y-%m-%d")
+            if instance.submission_date
+            else None
+        ),
     )
     self.assertEqual(payload.get("country", ""), instance.country)
     self.assertEqual(payload.get("region", ""), instance.region)
@@ -159,15 +168,19 @@ def _test_record(self, payload, instance, created=False):
             self.assertEqual(subrecord.get("test_pass"), subinstance.test_pass)
             self.assertEqual(
                 subrecord.get("test_start"),
-                subinstance.test_start.strftime("%Y-%m")
-                if subinstance.test_start
-                else None,
+                (
+                    subinstance.test_start.strftime("%Y-%m")
+                    if subinstance.test_start
+                    else None
+                ),
             )
             self.assertEqual(
                 subrecord.get("test_end"),
-                subinstance.test_end.strftime("%Y-%m")
-                if subinstance.test_end
-                else None,
+                (
+                    subinstance.test_end.strftime("%Y-%m")
+                    if subinstance.test_end
+                    else None
+                ),
             )
             self.assertEqual(subrecord.get("score_a"), subinstance.score_a)
             self.assertEqual(subrecord.get("score_b"), subinstance.score_b)

--- a/onyx/data/tests/utils.py
+++ b/onyx/data/tests/utils.py
@@ -86,6 +86,7 @@ def generate_test_data(n: int = 100):
             "score": random.random() * 42,
             "start": random.randint(1, 5),
             "end": random.randint(6, 10),
+            "required_when_published": "hello",
         }
         if records:
             x["records"] = [
@@ -95,6 +96,7 @@ def generate_test_data(n: int = 100):
                     "test_start": f"2022-{random.randint(1, 12)}",
                     "test_end": f"2023-{random.randint(1, 6)}",
                     "score_a": random.random() * 42,
+                    "test_result": "details",
                 },
                 {
                     "test_id": 2,
@@ -102,6 +104,7 @@ def generate_test_data(n: int = 100):
                     "test_start": f"2022-{random.randint(1, 12)}",
                     "test_end": f"2023-{random.randint(1, 6)}",
                     "score_b": random.random() * 42,
+                    "test_result": "details",
                 },
             ]
         data.append(x)

--- a/onyx/data/tests/views/test_choices.py
+++ b/onyx/data/tests/views/test_choices.py
@@ -14,7 +14,7 @@ class TestChoicesView(OnyxTestCase):
             "data.project.choices", kwargs={"code": "test", "field": field}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -150,7 +150,7 @@ class TestCreateView(OnyxTestCase):
         """
 
         payload = copy.deepcopy(default_payload)
-        payload["suppressed"] = "helloooo"
+        payload["is_suppressed"] = "helloooo"
         response = self.client.post(self.endpoint, data=payload)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert TestModel.objects.count() == 0

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -30,6 +30,7 @@ default_payload = {
     "score": 42.832,
     "start": 1,
     "end": 2,
+    "required_when_published": "hello",
     "records": [
         {
             "test_id": 1,
@@ -37,6 +38,7 @@ default_payload = {
             "test_start": "2023-01",
             "test_end": "2023-02",
             "score_a": 42.101,
+            "test_result": "details",
         },
         {
             "test_id": 2,
@@ -58,7 +60,7 @@ class TestCreateView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
 
     def test_basic(self):
@@ -224,6 +226,56 @@ class TestCreateView(OnyxTestCase):
         payload["records"][0]["score_a"] = 42.3
         payload["records"][0]["score_b"] = 42.3112
         payload["records"][0]["score_c"] = 42.4242
+        response = self.client.post(self.endpoint, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert TestModel.objects.count() == 1
+        assert TestModelRecord.objects.count() == 2
+        instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
+        _test_record(self, payload, instance, created=True)
+
+    def test_conditional_value_required_fields(self):
+        """
+        Test that a payload with missing conditional-value required fields fails.
+        """
+
+        payload = copy.deepcopy(default_payload)
+
+        # required_when_published is required when the record is being published
+        payload.pop("required_when_published")
+        response = self.client.post(self.endpoint, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert TestModel.objects.count() == 0
+        assert TestModelRecord.objects.count() == 0
+
+        # required_when_published is not required when the record is not published
+        payload["is_published"] = False
+        response = self.client.post(self.endpoint, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert TestModel.objects.count() == 1
+        assert TestModelRecord.objects.count() == 2
+        instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
+        payload["sample_id"] = response.json()["data"]["sample_id"]
+        payload["run_name"] = response.json()["data"]["run_name"]
+        _test_record(self, payload, instance, created=True)
+
+    def test_nested_conditional_value_required_fields(self):
+        """
+        Test that a nested conditional-value required constraint works.
+        """
+
+        payload = copy.deepcopy(default_payload)
+
+        # test_result is required when its test_pass is True
+        payload["records"][0].pop("test_result")
+        response = self.client.post(self.endpoint, data=payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert TestModel.objects.count() == 0
+        assert TestModelRecord.objects.count() == 0
+
+        # test_result is not required when its test_pass is False
+        payload["records"][0]["test_pass"] = False
         response = self.client.post(self.endpoint, data=payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         assert TestModel.objects.count() == 1

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -16,7 +16,7 @@ class TestDeleteView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),

--- a/onyx/data/tests/views/test_fields.py
+++ b/onyx/data/tests/views/test_fields.py
@@ -12,7 +12,7 @@ class TestFieldsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project.fields", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -19,7 +19,7 @@ class TestFilterView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         for payload in generate_test_data():
             response = self.client.post(self.endpoint, data=payload)

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -50,14 +50,17 @@ class TestGetView(OnyxTestCase):
             self.endpoint(self.climb_id),
             data={"include": ["climb_id", "published_date"]},
         )
+        record = TestModel.objects.get(climb_id=self.climb_id)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json()["data"],
             {
-                "climb_id": self.climb_id,
-                "published_date": TestModel.objects.get(
-                    climb_id=self.climb_id
-                ).published_date.strftime("%Y-%m-%d"),
+                "climb_id": record.climb_id,
+                "published_date": (
+                    record.published_date.strftime("%Y-%m-%d")
+                    if record.published_date
+                    else None
+                ),
             },
         )
 
@@ -109,7 +112,7 @@ class TestGetView(OnyxTestCase):
         """
 
         instance = TestModel.objects.get(climb_id=self.climb_id)
-        instance.suppressed = True
+        instance.is_suppressed = True
         instance.save()
 
         response = self.client.get(self.endpoint(self.climb_id))

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -15,7 +15,7 @@ class TestGetView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -15,7 +15,7 @@ class TestIdentifyView(OnyxTestCase):
             "data.project.identify", kwargs={"code": "test", "field": field}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         test_record = next(iter(generate_test_data(n=1)))
         self.input_sample_id = test_record["sample_id"]

--- a/onyx/data/tests/views/test_lookups.py
+++ b/onyx/data/tests/views/test_lookups.py
@@ -13,7 +13,7 @@ class TestLookupsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project.lookups", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -13,7 +13,7 @@ class TestProjectsView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.projects")
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
 
     def test_basic(self):
@@ -28,7 +28,7 @@ class TestProjectsView(OnyxTestCase):
             [
                 {
                     "project": "test",
-                    "scope": "test",
+                    "scope": "admin",
                     "actions": [action.value for action in Actions],
                 }
             ],

--- a/onyx/data/tests/views/test_query.py
+++ b/onyx/data/tests/views/test_query.py
@@ -15,7 +15,7 @@ class TestQueryView(OnyxTestCase):
         super().setUp()
         self.endpoint = reverse("data.project.query", kwargs={"code": "test"})
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         for payload in generate_test_data():
             response = self.client.post(

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -16,7 +16,7 @@ class TestUpdateView(OnyxTestCase):
             "data.project.climb_id", kwargs={"code": "test", "climb_id": climb_id}
         )
         self.user = self.setup_user(
-            "testuser", roles=["is_staff"], groups=["test.test"]
+            "testuser", roles=["is_staff"], groups=["test.admin"]
         )
         response = self.client.post(
             reverse("data.project", kwargs={"code": "test"}),

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -580,6 +580,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
         qs = init_project_queryset(
             model=self.model,
             user=request.user,
+            fields=self.handler.get_fields(),
         )
 
         # Get the instance to be updated
@@ -624,10 +625,24 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
         """
         Use the `climb_id` to permanently delete an instance of the given project `code`.
         """
+
+        if not request.user.is_staff:
+            # TODO: # This logic is currently unused as only staff members can access this endpoint
+            # If its opened to non-staff, the IsObjectSite permission will need to be added
+
+            # If the user is not staff, they can only delete instances if:
+            # The instance is published
+            # The instance is not suppressed
+            # The instance is not site restricted to a different site
+            fields = []
+        else:
+            fields = ["is_published", "is_suppressed", "is_site_restricted"]
+
         # Initial queryset
         qs = init_project_queryset(
             model=self.model,
             user=request.user,
+            fields=fields,
         )
 
         # Get the instance to be deleted

--- a/onyx/utils/constraints.py
+++ b/onyx/utils/constraints.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+from typing import Any
 from django.db import models
 from django.db.models import F, Q
 
@@ -7,7 +8,11 @@ from django.db.models import F, Q
 # TODO: Test constraints
 
 
-def unique_together(model_name: str, fields: list[str]):
+def unique_together(
+    model_name: str,
+    fields: list[str],
+    fields_name: str | None = None,
+):
     """
     Creates a unique constraint over the provided `fields`.
 
@@ -16,24 +21,33 @@ def unique_together(model_name: str, fields: list[str]):
     Args:
         model_name: The name of the model (used in naming the constraint).
         fields: The fields to create the constraint over.
+        fields_name: The name of the group of fields (used in naming the constraint).
 
     Returns:
         The constraint.
     """
 
+    if not fields_name:
+        fields_name = "_".join(fields)
+
     return models.UniqueConstraint(
         fields=fields,
-        name=f"unique_together_{model_name}_{'_'.join(fields)}",
+        name=f"unique_together_{model_name}_{fields_name}",
     )
 
 
-def optional_value_group(model_name: str, fields: list[str]):
+def optional_value_group(
+    model_name: str,
+    fields: list[str],
+    fields_name: str | None = None,
+):
     """
     Creates a constraint that ensures at least one of the provided `fields` is not null.
 
     Args:
         model_name: The name of the model (used in naming the constraint).
         fields: The fields to create the constraint over.
+        fields_name: The name of the group of fields (used in naming the constraint).
 
     Returns:
         The constraint.
@@ -46,22 +60,28 @@ def optional_value_group(model_name: str, fields: list[str]):
     # This is done by OR-ing the Q objects together
     check = functools.reduce(operator.or_, q_objects)
 
+    if not fields_name:
+        fields_name = "_".join(fields)
+
     return models.CheckConstraint(
         check=check,
-        name=f"optional_value_group_{model_name}_{'_'.join(fields)}",
-        violation_error_message="At least one of '"
-        + "', '".join(fields)
-        + "' is required.",
+        name=f"optional_value_group_{model_name}_{fields_name}",
+        violation_error_message=f"At least one of the fields within the group {fields_name} is required.",
     )
 
 
-def ordering(model_name: str, fields: tuple[str, str]):
+def ordering(
+    model_name: str,
+    fields: tuple[str, str],
+    fields_name: str | None = None,
+):
     """
     Creates a constraint that ensures the first field is less than or equal to the second field.
 
     Args:
         model_name: The name of the model (used in naming the constraint).
         fields: The fields to create the constraint over.
+        fields_name: The name of the group of fields (used in naming the constraint).
 
     Returns:
         The constraint.
@@ -70,7 +90,7 @@ def ordering(model_name: str, fields: tuple[str, str]):
     # Split the fields tuple into lower and higher
     lower, higher = fields
 
-    # Build a Q object that requires that either:
+    # Build a Q object that says either:
     # - One of the two fields is null
     # - The lower field is less than or equal to the higher field
     check = (
@@ -79,77 +99,143 @@ def ordering(model_name: str, fields: tuple[str, str]):
         | models.Q(**{f"{lower}__lte": models.F(higher)})
     )
 
+    if not fields_name:
+        fields_name = f"{lower}_{higher}"
+
     return models.CheckConstraint(
         check=check,
-        name=f"ordering_{model_name}_{lower}_{higher}",
+        name=f"ordering_{model_name}_{fields_name}",
         violation_error_message=f"The '{lower}' must be less than or equal to '{higher}'.",
     )
 
 
-def non_futures(model_name: str, fields: list[str]):
+def non_futures(
+    model_name: str,
+    fields: list[str],
+    fields_name: str | None = None,
+):
     """
     Creates a constraint that ensures that the provided `fields` are not from the future.
 
     Args:
         model_name: The name of the model (used in naming the constraint).
         fields: The fields to create the constraint over.
+        fields_name: The name of the group of fields (used in naming the constraint).
 
     Returns:
         The constraint.
     """
 
-    # For each field, build a Q object that requires the field is null or less than or equal to the last_modified field
-    q_objects = [
-        Q(**{f"{field}__isnull": True}) | Q(**{f"{field}__lte": F("last_modified")})
-        for field in fields
-    ]
-
-    # Reduce the Q objects into a single Q object that requires all of the fields are not from the future
-    # This is done by AND-ing the Q objects together
+    # Build a Q object that says (for each field) either:
+    # - The field is null
+    # - The field's value is less than or equal to the last_modified field
     check = functools.reduce(
         operator.and_,
-        q_objects,
+        [
+            Q(**{f"{field}__isnull": True}) | Q(**{f"{field}__lte": F("last_modified")})
+            for field in fields
+        ],
     )
+
+    if not fields_name:
+        fields_name = "_".join(fields)
 
     return models.CheckConstraint(
         check=check,
-        name=f"non_future_{model_name}_{'_'.join(fields)}",
-        violation_error_message="At least one of '"
-        + "', '".join(fields)
-        + "' is from the future.",
+        name=f"non_future_{model_name}_{fields_name}",
+        violation_error_message=f"At least one of the fields within the group {fields_name} is from the future.",
     )
 
 
-def conditional_required(model_name: str, field: str, required: list[str]):
+def conditional_required(
+    model_name: str,
+    field: str,
+    required: list[str],
+    required_name: str | None = None,
+):
     """
-    Creates a constraint that ensures that the provided `field` must be null unless all of the `required` fields are not null.
+    Creates a constraint that ensures that the `field` can only be not null when all of the `required` fields are not null.
 
     Args:
         model_name: The name of the model (used in naming the constraint).
         field: The field to create the constraint over.
         required: The fields that are required in order to set the `field`.
+        required_name: The name of the group of required fields (used in naming the constraint).
 
     Returns:
         The constraint.
     """
 
-    # For each required field, build a Q object that requires the field is not null
-    q_objects = [Q(**{f"{req}__isnull": False}) for req in required]
+    # Build a Q object that says all of the required fields are not null
+    requirements = functools.reduce(
+        operator.and_, [Q(**{f"{req}__isnull": False}) for req in required]
+    )
 
-    # Reduce the Q objects into a single Q object that requires all of the required fields are not null
-    requirements = functools.reduce(operator.and_, q_objects)
+    # Build a Q object that says the field is not null
+    condition = Q(**{f"{field}__isnull": False})
 
-    # Build a Q object that requires that either:
-    # - The field is null
-    # - All of the required fields are not null
-    check = Q(**{f"{field}__isnull": True}) | requirements
+    # We have the following:
+    # - condition: The field is not null
+    # - requirements: All of the required fields are not null
+    # We want a Q object that satisfies the following condition:
+    # condition IMPLIES requirements
+    # This is logically equivalent to:
+    # (NOT condition) OR requirements
+    check = (~condition) | requirements
+
+    if not required_name:
+        required_name = "_".join(required)
 
     return models.CheckConstraint(
         check=check,
-        name=f"conditional_required_{model_name}_{field}_requires_{'_'.join(required)}",
-        violation_error_message="All of '"
-        + "', '".join(required)
-        + "' are required in order to set "
-        + field
-        + ".",
+        name=f"conditional_required_{model_name}_{field}_requires_{required_name}",
+        violation_error_message=f"All fields within the group {required_name} are required in order to set {field}.",
+    )
+
+
+def conditional_value_required(
+    model_name: str,
+    field: str,
+    value: Any,
+    required: list[str],
+    required_name: str | None = None,
+):
+    """
+    Creates a constraint that ensures that the `field` can only be set to the `value` when all of the `required` fields are not null.
+
+    Args:
+        model_name: The name of the model (used in naming the constraint).
+        field: The field to create the constraint over.
+        value: The value that the `field` is required to be set to.
+        required: The fields that are required in order to set the `field` to the `value`.
+        required_name: The name of the group of required fields (used in naming the constraint).
+
+    Returns:
+        The constraint.
+    """
+
+    # Build a Q object that says all of the required fields are not null
+    requirements = functools.reduce(
+        operator.and_, [Q(**{f"{req}__isnull": False}) for req in required]
+    )
+
+    # Build a Q object that says the field is equal to the value
+    condition = Q(**{field: value})
+
+    # We have the following:
+    # - condition: The field is equal to the value
+    # - requirements: All of the required fields are not null
+    # We want a Q object that satisfies the following condition:
+    # condition IMPLIES requirements
+    # This is logically equivalent to:
+    # (NOT condition) OR requirements
+    check = (~condition) | requirements
+
+    if not required_name:
+        required_name = "_".join(required)
+
+    return models.CheckConstraint(
+        check=check,
+        name=f"conditional_value_required_{model_name}_{field}_value_requires_{required_name}",
+        violation_error_message=f"All fields within the group {required_name} are required in order to set {field} to the value.",
     )


### PR DESCRIPTION
- Renamed `suppressed` and `site_restricted` fields to `is_suppressed` and `is_site_restricted`. 
- Added `is_published` field. 
- Altered `init_project_queryset` logic. Now follows simple principle:
   - If the user cannot action on `is_suppressed`, then the queryset excludes suppressed data.
   - If the user cannot action on `is_published`, then the queryset excludes unpublished data.
   - If the user cannot action on `is_site_restricted`, then the queryset excludes site-restricted data from any site different to the requesting user.
- Added `conditional_value_required` validator/constraint.
- Improved and explained constraints logic, e.g. with logical proofs for 'implies' constraints.
- **Constraint names are now auto-generated, much shorter, and guaranteed unique**.
   - Realised that databases cap the length of a constraint name, so the list of fields is no longer included in the name.
   - Now, we have a truncated field list, alongside a hash of the app, model, fields and constraint type, which ensures an added unique value in the constraint name.
- Set `published_date` to be optional, but required if `is_published == True`. This field will now be automatically populated with the current date when the `is_published` field is set to `True` and the `published_date` is empty (i.e. it will be set the first time `is_published` equals `True`).