### PR TITLE
Bug fixes for management commands and prefetching is only done on returned fields

### DIFF
--- a/onyx/accounts/management/commands/site.py
+++ b/onyx/accounts/management/commands/site.py
@@ -17,7 +17,7 @@ def create_site(
 ) -> None:
     """
     Create/update a site with the given code and description.
-    
+
     Args:
         code: The code of the site.
         description: The description of the site.
@@ -114,9 +114,9 @@ class Command(base.BaseCommand):
             try:
                 site = Site.objects.get(code=options["code"])
             except Site.DoesNotExist:
-                print(f"Site with code '{options["code"]}' does not exist.")
+                print(f"Site with code '{options['code']}' does not exist.")
                 exit()
-            
+
             print("Site:", site.code)
 
             if options["command"] == "roles":
@@ -131,7 +131,7 @@ class Command(base.BaseCommand):
                     print("Granted roles:")
                     for role in granted:
                         print(f"• {role}")
-                
+
                 if revoked:
                     print("Revoked roles:")
                     for role in revoked:
@@ -140,4 +140,4 @@ class Command(base.BaseCommand):
                 if not granted and not revoked:
                     print("Roles:")
                     for role in ROLES:
-                        print(f"• {role}: {getattr(site, role)}")       
+                        print(f"• {role}: {getattr(site, role)}")

--- a/onyx/accounts/management/commands/user.py
+++ b/onyx/accounts/management/commands/user.py
@@ -16,7 +16,7 @@ def create_user(
     username: str,
     site: str,
     password: Optional[str] = None,
- ) -> None:
+) -> None:
     """
     Create a user with the given username, site and optional password.
 
@@ -28,7 +28,7 @@ def create_user(
         password: The password of the user.
     """
 
-    # TODO: Functionality for updating a user
+    # TODO: Functionality for updating a user
 
     if User.objects.filter(username=username).exists():
         print(f"User with username '{username}' already exists.")
@@ -65,10 +65,14 @@ def list_users() -> None:
             {
                 "username": user.username,
                 "site": user.site.code,
-                "site_projects" : ",".join(user.site.projects.values_list("code", flat=True)),
+                "site_projects": ",".join(
+                    user.site.projects.values_list("code", flat=True)
+                ),
                 "creator": user.creator.username if user.creator else None,
                 "date_joined": user.date_joined.strftime("%Y-%m-%d"),
-                "last_login": user.last_login.strftime("%Y-%m-%d") if user.last_login else None,
+                "last_login": (
+                    user.last_login.strftime("%Y-%m-%d") if user.last_login else None
+                ),
                 "is_active": user.is_active,
                 "is_approved": user.is_approved,
                 "is_staff": user.is_staff,
@@ -130,11 +134,11 @@ class Command(base.BaseCommand):
             try:
                 user = User.objects.get(username=options["user"])
             except User.DoesNotExist:
-                print(f"User with username '{options["user"]}' does not exist.")
+                print(f"User with username '{options['user']}' does not exist.")
                 exit()
 
             print("User:", user.username)
-            
+
             if options["command"] == "roles":
                 granted, revoked = manage_instance_roles(
                     user,
@@ -147,7 +151,7 @@ class Command(base.BaseCommand):
                     print("Granted roles:")
                     for role in granted:
                         print(f"• {role}")
-                
+
                 if revoked:
                     print("Revoked roles:")
                     for role in revoked:

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -479,18 +479,8 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
             exclude=self.exclude,
         )
 
-        # Nested fields that are returned or filtered will be prefetched
-        prefetch_fields = fields + [
-            onyx_field.field_path
-            for onyx_field in filter_fields.values()
-            if onyx_field.field_path not in fields
-        ]
-
-        # TODO: Prefetching is applied only when filtering on a related field.
-        # e.g. 'related__field' triggers prefetching of related, but 'related__isnull'
-        # does not. Performance tests have shown this not to be an issue,
-        # but should look more into this to see if optimisations can be made
-        qs = prefetch_nested(qs, unflatten_fields(prefetch_fields))
+        # Prefetch nested fields returned in response
+        qs = prefetch_nested(qs, unflatten_fields(fields))
 
         # If data was provided, then it has now been validated
         # So we form the Q object, and filter the queryset with it

--- a/onyx/onyx/urls.py
+++ b/onyx/onyx/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 # from django.contrib import admin
 from django.urls import path, include
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.12.0"
+version = "0.12.1"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Bug fixes for management commands where f-strings use backwards-incompatible (less than python 3.12) syntax
- Prefetching only done on returned fields, following tests on large amounts of nested data