### PR TITLE
Bug fixes involving `null` values passed to certain lookups in queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.15.6"
+version = "0.15.7"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- 'Strict' versions of most forms/filters have been introduced, where `None` values are not accepted (in opposition to non-strict versions, where they are allowed). The only exception to this is the `BaseRangeField` subclasses, as `range` is strict by default.
- This enables per-lookup control of whether `None` values are accepted or not in a query. From this, bugs such as an ISE when passing a `null` value to an inequality lookup, or difficult-to-explain behaviour such as providing a `null` value to a `length` lookup have now been removed.