### PR TITLE
`TypesView`, `LookupsView`, and url renaming

### DIFF
--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -11,7 +11,7 @@ from utils.fields import (
 from utils.functions import get_suggestions, get_permission, parse_permission
 from accounts.models import User
 from .models import Choice, Project, ProjectRecord
-from .types import OnyxType, ALL_LOOKUPS
+from .types import OnyxLookup, OnyxType
 
 
 class OnyxField:
@@ -283,7 +283,7 @@ class FieldHandler:
             field_path = "__".join(components[: i + 1])
             lookup = "__".join(components[i + 1 :])
 
-            if lookup in ALL_LOOKUPS:
+            if lookup in OnyxLookup.lookups():
                 # The field is valid, and the lookup is not sus
                 # So we attempt to instantiate the field instance
                 # This could fail if the lookup is not allowed for the given field

--- a/onyx/data/models.py
+++ b/onyx/data/models.py
@@ -11,7 +11,7 @@ from accounts.models import Site, User
 from utils.fields import StrippedCharField, LowerCharField, UpperCharField, SiteField
 from utils.constraints import unique_together
 from simple_history.models import HistoricalRecords
-from .types import ALL_LOOKUPS
+from .types import OnyxLookup
 
 
 class Project(models.Model):
@@ -97,7 +97,7 @@ class BaseRecord(models.Model):
         errors = super().check(**kwargs)
 
         for field in cls._meta.get_fields():
-            if field.name in ALL_LOOKUPS:
+            if field.name in OnyxLookup.lookups():
                 errors.append(
                     checks.Error(
                         f"Field names must not match existing lookups.",

--- a/onyx/data/tests/views/test_choices.py
+++ b/onyx/data/tests/views/test_choices.py
@@ -11,7 +11,7 @@ class TestChoicesView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda field: reverse(
-            "project.testproject.choices",
+            "projects.testproject.choices.field",
             kwargs={"code": self.project.code, "field": field},
         )
 

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -59,7 +59,7 @@ class TestCreateView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject", kwargs={"code": self.project.code}
+            "projects.testproject", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):
@@ -84,7 +84,7 @@ class TestCreateView(OnyxTestCase):
 
         payload = copy.deepcopy(default_payload)
         response = self.client.post(
-            reverse("project.testproject.test", kwargs={"code": self.project.code}),
+            reverse("projects.testproject.test", kwargs={"code": self.project.code}),
             data=payload,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -13,11 +13,11 @@ class TestDeleteView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_fields.py
+++ b/onyx/data/tests/views/test_fields.py
@@ -11,7 +11,7 @@ class TestFieldsView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject.fields", kwargs={"code": self.project.code}
+            "projects.testproject.fields", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -13,7 +13,7 @@ class TestFilterView(OnyxDataTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject", kwargs={"code": self.project.code}
+            "projects.testproject", kwargs={"code": self.project.code}
         )
 
     def _test_filter(self, field, value, qs, lookup="", allow_empty=False):

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -12,11 +12,11 @@ class TestGetView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -15,7 +15,7 @@ class TestIdentifyView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda field: reverse(
-            "project.testproject.identify",
+            "projects.testproject.identify.field",
             kwargs={"code": self.project.code, "field": field},
         )
 
@@ -37,7 +37,7 @@ class TestIdentifyView(OnyxTestCase):
             start=1,
         ):
             result = self.client.post(
-                reverse("project.testproject", kwargs={"code": self.project.code}),
+                reverse("projects.testproject", kwargs={"code": self.project.code}),
                 data=record,
             )
             self.assertEqual(result.status_code, status.HTTP_201_CREATED)
@@ -89,7 +89,7 @@ class TestIdentifyView(OnyxTestCase):
         iterator = iter(generate_test_data(n=2))
         test_record_1 = next(iterator)
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_1,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -99,7 +99,7 @@ class TestIdentifyView(OnyxTestCase):
         test_record_2 = next(iterator)
         test_record_2["run_name"] = test_record_1["run_name"]
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_2,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -127,7 +127,7 @@ class TestIdentifyView(OnyxTestCase):
         iterator = iter(generate_test_data(n=2))
         test_record_1 = next(iterator)
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_1,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -139,7 +139,7 @@ class TestIdentifyView(OnyxTestCase):
         test_record_2["sample_id"] = test_record_1["sample_id"]
         test_record_2["run_name"] = test_record_1["run_name"]
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_2,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_lookups.py
+++ b/onyx/data/tests/views/test_lookups.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase
-from ...types import OnyxType
+from ...types import OnyxLookup, OnyxType
 
 
 class TestLookupsView(OnyxTestCase):
@@ -11,16 +11,25 @@ class TestLookupsView(OnyxTestCase):
         """
 
         super().setUp()
-        self.endpoint = reverse(
-            "project.testproject.lookups", kwargs={"code": self.project.code}
-        )
+        self.endpoint = reverse("projects.lookups")
 
     def test_basic(self):
         """
-        Test retrieval of available lookups for a project.
+        Test retrieval of available lookups.
         """
 
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        lookups = {onyx_type.label: onyx_type.lookups for onyx_type in OnyxType}
+        lookups = [
+            {
+                "lookup": onyx_lookup.label,
+                "description": onyx_lookup.description,
+                "types": [
+                    onyx_type.label
+                    for onyx_type in OnyxType
+                    if onyx_lookup.label in onyx_type.lookups
+                ],
+            }
+            for onyx_lookup in OnyxLookup
+        ]
         self.assertEqual(response.json()["data"], lookups)

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -11,7 +11,7 @@ class TestProjectsView(OnyxTestCase):
         """
 
         super().setUp()
-        self.endpoint = reverse("data.projects")
+        self.endpoint = reverse("projects")
 
     def test_basic(self):
         """

--- a/onyx/data/tests/views/test_query.py
+++ b/onyx/data/tests/views/test_query.py
@@ -15,7 +15,7 @@ class TestQueryView(OnyxDataTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject.query", kwargs={"code": self.project.code}
+            "projects.testproject.query", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_types.py
+++ b/onyx/data/tests/views/test_types.py
@@ -1,0 +1,32 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from ..utils import OnyxTestCase
+from ...types import OnyxType
+
+
+class TestTypesView(OnyxTestCase):
+    def setUp(self):
+        """
+        Create a user with the required permissions.
+        """
+
+        super().setUp()
+        self.endpoint = reverse("projects.types")
+
+    def test_basic(self):
+        """
+        Test retrieval of available types.
+        """
+
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        types = [
+            {
+                "type": onyx_type.label,
+                "description": onyx_type.description,
+                "lookups": [lookup for lookup in onyx_type.lookups if lookup],
+            }
+            for onyx_type in OnyxType
+        ]
+
+        self.assertEqual(response.json()["data"], types)

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -14,11 +14,11 @@ class TestUpdateView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -60,7 +60,7 @@ class TestUpdateView(OnyxTestCase):
         }
         response = self.client.patch(
             reverse(
-                "project.testproject.test.climb_id",
+                "projects.testproject.test.climb_id",
                 kwargs={"code": self.project.code, "climb_id": self.climb_id},
             ),
             data=updated_values,

--- a/onyx/data/types.py
+++ b/onyx/data/types.py
@@ -111,6 +111,14 @@ class OnyxLookup(Enum):
         self.label = label
         self.description = description
 
+    @classmethod
+    def lookups(cls):
+        """
+        Returns the set of all lookup labels.
+        """
+
+        return {""} | {lookup.label for lookup in cls}
+
 
 class OnyxType(Enum):
     TEXT = (
@@ -251,6 +259,3 @@ class OnyxType(Enum):
         self.label = label
         self.description = description
         self.lookups = lookups
-
-
-ALL_LOOKUPS = set(lookup for onyx_type in OnyxType for lookup in onyx_type.lookups)

--- a/onyx/data/types.py
+++ b/onyx/data/types.py
@@ -1,135 +1,255 @@
 from enum import Enum
 
 
+class OnyxLookup(Enum):
+    EXACT = (
+        "exact",
+        "The field's value must be equal to the query value.",
+    )
+    NE = (
+        "ne",
+        "The field's value must not be equal to the query value.",
+    )
+    IN = (
+        "in",
+        "The field's value must be in the list of query values.",
+    )
+    NOTIN = (
+        "notin",
+        "The field's value must not be in the list of query values.",
+    )
+    CONTAINS = (
+        "contains",
+        "The field's value must contain the query value.",
+    )
+    STARTSWITH = (
+        "startswith",
+        "The field's value must start with the query value.",
+    )
+    ENDSWITH = (
+        "endswith",
+        "The field's value must end with the query value.",
+    )
+    IEXACT = (
+        "iexact",
+        "The field's value must be equal to the query value, ignoring case.",
+    )
+    ICONTAINS = (
+        "icontains",
+        "The field's value must contain the query value, ignoring case.",
+    )
+    ISTARTSWITH = (
+        "istartswith",
+        "The field's value must start with the query value, ignoring case.",
+    )
+    IENDSWITH = (
+        "iendswith",
+        "The field's value must end with the query value, ignoring case.",
+    )
+    LENGTH = (
+        "length",
+        "The length of the field's value must be equal to the query value.",
+    )
+    LENGTH_IN = (
+        "length__in",
+        "The length of the field's value must be in the list of query values.",
+    )
+    LENGTH_RANGE = (
+        "length__range",
+        "The length of the field's value must be in the range of query values.",
+    )
+    LT = (
+        "lt",
+        "The field's value must be less than the query value.",
+    )
+    LTE = (
+        "lte",
+        "The field's value must be less than or equal to the query value.",
+    )
+    GT = (
+        "gt",
+        "The field's value must be greater than the query value.",
+    )
+    GTE = (
+        "gte",
+        "The field's value must be greater than or equal to the query value.",
+    )
+    RANGE = (
+        "range",
+        "The field's value must be in the range of query values.",
+    )
+    ISO_YEAR = (
+        "iso_year",
+        "The ISO 8601 week-numbering year of the field's value must be equal to the query value.",
+    )
+    ISO_YEAR_IN = (
+        "iso_year__in",
+        "The ISO 8601 week-numbering year of the field's value must be in the list of query values.",
+    )
+    ISO_YEAR_RANGE = (
+        "iso_year__range",
+        "The ISO 8601 week-numbering year of the field's value must be in the range of query values.",
+    )
+    WEEK = (
+        "week",
+        "The ISO 8601 week number of the field's value must be equal to the query value.",
+    )
+    WEEK_IN = (
+        "week__in",
+        "The ISO 8601 week number of the field's value must be in the list of query values.",
+    )
+    WEEK_RANGE = (
+        "week__range",
+        "The ISO 8601 week number of the field's value must be in the range of query values.",
+    )
+    ISNULL = (
+        "isnull",
+        "The field's value must be empty.",
+    )
+
+    def __init__(self, label, description) -> None:
+        self.label = label
+        self.description = description
+
+
 class OnyxType(Enum):
     TEXT = (
         "text",
+        "A string of characters.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "contains",
-            "startswith",
-            "endswith",
-            "iexact",
-            "icontains",
-            "istartswith",
-            "iendswith",
-            "length",
-            "length__in",
-            "length__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.CONTAINS.label,
+            OnyxLookup.STARTSWITH.label,
+            OnyxLookup.ENDSWITH.label,
+            OnyxLookup.IEXACT.label,
+            OnyxLookup.ICONTAINS.label,
+            OnyxLookup.ISTARTSWITH.label,
+            OnyxLookup.IENDSWITH.label,
+            OnyxLookup.LENGTH.label,
+            OnyxLookup.LENGTH_IN.label,
+            OnyxLookup.LENGTH_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     CHOICE = (
         "choice",
+        "A restricted set of options.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     INTEGER = (
         "integer",
+        "A whole number.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DECIMAL = (
         "decimal",
+        "A decimal number.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DATE = (
         "date",
+        "A date.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "iso_year",
-            "iso_year__in",
-            "iso_year__range",
-            "week",
-            "week__in",
-            "week__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISO_YEAR.label,
+            OnyxLookup.ISO_YEAR_IN.label,
+            OnyxLookup.ISO_YEAR_RANGE.label,
+            OnyxLookup.WEEK.label,
+            OnyxLookup.WEEK_IN.label,
+            OnyxLookup.WEEK_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DATETIME = (
         "datetime",
+        "A date and time.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "iso_year",
-            "iso_year__in",
-            "iso_year__range",
-            "week",
-            "week__in",
-            "week__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISO_YEAR.label,
+            OnyxLookup.ISO_YEAR_IN.label,
+            OnyxLookup.ISO_YEAR_RANGE.label,
+            OnyxLookup.WEEK.label,
+            OnyxLookup.WEEK_IN.label,
+            OnyxLookup.WEEK_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     BOOLEAN = (
         "bool",
+        "A true or false value.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     RELATION = (
         "relation",
+        "A link to a row, or multiple rows, in another table.",
         [
-            "isnull",
+            OnyxLookup.ISNULL.label,
         ],
     )
 
-    def __init__(self, label, lookups) -> None:
+    def __init__(self, label, description, lookups) -> None:
         self.label = label
+        self.description = description
         self.lookups = lookups
 
 

--- a/onyx/data/urls.py
+++ b/onyx/data/urls.py
@@ -8,7 +8,17 @@ urlpatterns = [
     path(
         "",
         views.ProjectsView.as_view(),
-        name="data.projects",
+        name="projects",
+    ),
+    path(
+        "types/",
+        views.TypesView.as_view(),
+        name=f"projects.types",
+    ),
+    path(
+        "lookups/",
+        views.LookupsView.as_view(),
+        name=f"projects.lookups",
     ),
 ]
 
@@ -29,9 +39,9 @@ def generate_project_urls(
 
     return [
         path(
-            r"",
+            "",
             views.ProjectRecordsViewSet.as_view({"post": "create", "get": "list"}),
-            name=f"project.{code}",
+            name=f"projects.{code}",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
@@ -39,49 +49,43 @@ def generate_project_urls(
             views.ProjectRecordsViewSet.as_view(
                 {"get": "retrieve", "patch": "partial_update", "delete": "destroy"}
             ),
-            name=f"project.{code}.climb_id",
+            name=f"projects.{code}.climb_id",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
-        re_path(
-            r"^test/$",
+        path(
+            "test/",
             views.ProjectRecordsViewSet.as_view({"post": "create"}),
-            name=f"project.{code}.test",
+            name=f"projects.{code}.test",
             kwargs={"code": code, "serializer_class": serializer_class, "test": True},
         ),
         re_path(
             r"^test/(?P<climb_id>[cC]-[a-zA-Z0-9]{10})/$",
             views.ProjectRecordsViewSet.as_view({"patch": "partial_update"}),
-            name=f"project.{code}.test.climb_id",
+            name=f"projects.{code}.test.climb_id",
             kwargs={"code": code, "serializer_class": serializer_class, "test": True},
         ),
-        re_path(
-            r"^query/$",
+        path(
+            "query/",
             views.ProjectRecordsViewSet.as_view({"post": "list"}),
-            name=f"project.{code}.query",
+            name=f"projects.{code}.query",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
-        re_path(
-            r"^fields/$",
+        path(
+            "fields/",
             views.FieldsView.as_view(),
-            name=f"project.{code}.fields",
-            kwargs={"code": code, "serializer_class": serializer_class},
-        ),
-        re_path(
-            r"^lookups/$",
-            views.LookupsView.as_view(),
-            name=f"project.{code}.lookups",
+            name=f"projects.{code}.fields",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
             r"^choices/(?P<field>[a-zA-Z0-9_]*)/$",
             views.ChoicesView.as_view(),
-            name=f"project.{code}.choices",
+            name=f"projects.{code}.choices.field",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
             r"^identify/(?P<field>[a-zA-Z0-9_]*)/$",
             views.IdentifyView.as_view(),
-            name=f"project.{code}.identify",
+            name=f"projects.{code}.identify.field",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
     ]


### PR DESCRIPTION
- Added `OnyxLookup` enum class, with classmethod `lookups` to replace the `ALL_LOOKUPS` global variable
- Renamed `data` urls to follow consistent naming scheme
- Added `TypesView` for retrieving a list of field types with descriptions and their lookups, and refactored `LookupsView` into a list of lookups with descriptions and their types