### PR TITLE
History endpoint, action descriptions

### DIFF
--- a/onyx/accounts/permissions.py
+++ b/onyx/accounts/permissions.py
@@ -120,11 +120,11 @@ class IsProjectApproved(permissions.BasePermission):
         # Check the user's permission to perform action on the project
         project_action_permission = get_permission(
             app_label=project.content_type.app_label,
-            action=view.project_action,
+            action=view.project_action.label,
             code=project.code,
         )
         if not request.user.has_perm(project_action_permission):
-            self.message = f"You do not have permission to {view.project_action} on the {project.name} project."
+            self.message = f"You do not have permission to {view.project_action.description} the {project.name} project."
             return False
 
         # If the user has permission to access and perform the action on the project, then they have permission

--- a/onyx/data/actions.py
+++ b/onyx/data/actions.py
@@ -2,10 +2,16 @@ from enum import Enum
 
 
 class Actions(Enum):
-    GET = "get"
-    LIST = "list"
-    FILTER = "filter"
-    IDENTIFY = "identify"
-    ADD = "add"
-    CHANGE = "change"
-    DELETE = "delete"
+    ACCESS = ("access", "access")
+    GET = ("get", "get a record from")
+    LIST = ("list", "list records from")
+    FILTER = ("filter", "filter records from")
+    HISTORY = ("history", "get a record's history from")
+    IDENTIFY = ("identify", "identify a value from")
+    ADD = ("add", "add a record to")
+    CHANGE = ("change", "change a record on")
+    DELETE = ("delete", "delete a record on")
+
+    def __init__(self, label: str, description: str) -> None:
+        self.label = label
+        self.description = description

--- a/onyx/data/serializers.py
+++ b/onyx/data/serializers.py
@@ -31,6 +31,7 @@ class HistoryDiffSerializer(serializers.Serializer):
     """
 
     field = serializers.CharField()
+    type = serializers.CharField()
 
     def __init__(
         self,

--- a/onyx/data/spec.py
+++ b/onyx/data/spec.py
@@ -84,9 +84,9 @@ def generate_fields_spec(
             "type": onyx_type.label,
             "required": required,
             "actions": [
-                action.value
+                action.label
                 for action in Actions
-                if action.value in actions_map[field_path]
+                if action.label in actions_map[field_path]
             ],
         }
 
@@ -167,9 +167,9 @@ def generate_fields_spec(
             "type": onyx_type.label,
             "required": onyx_fields[field_path].required,
             "actions": [
-                action.value
+                action.label
                 for action in Actions
-                if action.value in actions_map[field_path]
+                if action.label in actions_map[field_path]
             ],
             # Recursively generate fields spec for the nested serializer
             "fields": generate_fields_spec(

--- a/onyx/data/tests/views/test_history.py
+++ b/onyx/data/tests/views/test_history.py
@@ -4,6 +4,7 @@ from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase, generate_test_data
 from ...exceptions import ClimbIDNotFound
 from ...actions import Actions
+from ...types import OnyxType
 from projects.testproject.models import TestModel
 
 
@@ -91,6 +92,11 @@ class TestHistoryView(OnyxTestCase):
         )
 
         self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        types = {
+            "submission_date": OnyxType.DATE.label,
+            "tests": OnyxType.INTEGER.label,
+            "text_option_2": OnyxType.TEXT.label,
+        }
         for change in response.json()["data"]["history"][1]["changes"]:
             from_value = getattr(instance, change["field"])
             if isinstance(from_value, date):
@@ -100,6 +106,7 @@ class TestHistoryView(OnyxTestCase):
             if isinstance(to_value, date):
                 to_value = to_value.strftime("%Y-%m-%d")
 
+            self.assertEqual(change["type"], types[change["field"]])
             self.assertEqual(change["from"], from_value)
             self.assertEqual(change["to"], to_value)
 
@@ -174,6 +181,11 @@ class TestHistoryView(OnyxTestCase):
         )
 
         self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        types = {
+            "submission_date": OnyxType.DATE.label,
+            "tests": OnyxType.INTEGER.label,
+            "text_option_2": OnyxType.TEXT.label,
+        }
         for change in response.json()["data"]["history"][1]["changes"]:
             from_value = getattr(instance, change["field"])
             if isinstance(from_value, date):
@@ -183,15 +195,17 @@ class TestHistoryView(OnyxTestCase):
             if isinstance(to_value, date):
                 to_value = to_value.strftime("%Y-%m-%d")
 
+            self.assertEqual(change["type"], types[change["field"]])
             self.assertEqual(change["from"], from_value)
             self.assertEqual(change["to"], to_value)
 
         self.assertEqual(len(response.json()["data"]["history"][2]["changes"]), 2)
         for change in response.json()["data"]["history"][2]["changes"]:
+            self.assertEqual(change["field"], "records")
+            self.assertEqual(change["type"], OnyxType.RELATION.label)
+
             if change["count"] == 1:
-                self.assertEqual(change["field"], "records")
                 self.assertEqual(change["action"], Actions.ADD.label)
             else:
-                self.assertEqual(change["field"], "records")
                 self.assertEqual(change["action"], Actions.CHANGE.label)
                 self.assertEqual(change["count"], 2)

--- a/onyx/data/tests/views/test_history.py
+++ b/onyx/data/tests/views/test_history.py
@@ -1,0 +1,197 @@
+from datetime import timedelta, date
+from rest_framework import status
+from rest_framework.reverse import reverse
+from ..utils import OnyxTestCase, generate_test_data
+from ...exceptions import ClimbIDNotFound
+from ...actions import Actions
+from projects.testproject.models import TestModel
+
+
+class TestHistoryView(OnyxTestCase):
+    def setUp(self):
+        """
+        Create a user with the required permissions and create a test record.
+        """
+
+        super().setUp()
+        self.endpoint = lambda climb_id: reverse(
+            "projects.testproject.history.climb_id",
+            kwargs={"code": self.project.code, "climb_id": climb_id},
+        )
+        response = self.client.post(
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
+            data=next(iter(generate_test_data(n=1))),
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.climb_id = response.json()["data"]["climb_id"]
+
+    def test_basic(self):
+        """
+        Test getting the history of a record by CLIMB ID.
+        """
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 1)
+        self.assertEqual(
+            response.json()["data"]["history"][0]["username"], self.user.username
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+
+    def test_climb_id_not_found(self):
+        """
+        Test getting the history of a record by CLIMB ID that does not exist.
+        """
+
+        prefix, postfix = self.climb_id.split("-")
+        climb_id_not_found = "-".join([prefix, postfix[::-1]])
+        response = self.client.get(self.endpoint(climb_id_not_found))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.json()["messages"]["detail"], ClimbIDNotFound.default_detail
+        )
+
+    def test_change_history(self):
+        """
+        Test getting the history of a record by CLIMB ID after an update.
+        """
+
+        instance = TestModel.objects.get(climb_id=self.climb_id)
+        assert instance.submission_date is not None
+        assert instance.tests is not None
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 2)
+        for diff in response.json()["data"]["history"]:
+            self.assertEqual(diff["username"], self.user.username)
+
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][1]["action"], Actions.CHANGE.label
+        )
+
+        self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        for change in response.json()["data"]["history"][1]["changes"]:
+            from_value = getattr(instance, change["field"])
+            if isinstance(from_value, date):
+                from_value = from_value.strftime("%Y-%m-%d")
+
+            to_value = updated_values[change["field"]]
+            if isinstance(to_value, date):
+                to_value = to_value.strftime("%Y-%m-%d")
+
+            self.assertEqual(change["from"], from_value)
+            self.assertEqual(change["to"], to_value)
+
+    def test_nested_change_history(self):
+        """
+        Test getting the history of a record by CLIMB ID after an update with nested fields.
+        """
+
+        instance = TestModel.objects.get(climb_id=self.climb_id)
+        assert instance.submission_date is not None
+        assert instance.tests is not None
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+            "records": [
+                {
+                    "test_id": 1,
+                    "test_result": "more_details",
+                },
+                {
+                    "test_id": 2,
+                    "test_result": "more_details",
+                },
+                {
+                    "test_id": 1000,
+                    "test_pass": True,
+                    "test_start": "2024-01",
+                    "test_end": "2024-01",
+                    "score_a": 1,
+                    "score_b": 1,
+                    "test_result": "details",
+                },
+            ],
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 3)
+        for diff in response.json()["data"]["history"]:
+            self.assertEqual(diff["username"], self.user.username)
+
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][1]["action"], Actions.CHANGE.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][2]["action"], Actions.CHANGE.label
+        )
+
+        self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        for change in response.json()["data"]["history"][1]["changes"]:
+            from_value = getattr(instance, change["field"])
+            if isinstance(from_value, date):
+                from_value = from_value.strftime("%Y-%m-%d")
+
+            to_value = updated_values[change["field"]]
+            if isinstance(to_value, date):
+                to_value = to_value.strftime("%Y-%m-%d")
+
+            self.assertEqual(change["from"], from_value)
+            self.assertEqual(change["to"], to_value)
+
+        self.assertEqual(len(response.json()["data"]["history"][2]["changes"]), 2)
+        for change in response.json()["data"]["history"][2]["changes"]:
+            if change["count"] == 1:
+                self.assertEqual(change["field"], "records")
+                self.assertEqual(change["action"], Actions.ADD.label)
+            else:
+                self.assertEqual(change["field"], "records")
+                self.assertEqual(change["action"], Actions.CHANGE.label)
+                self.assertEqual(change["count"], 2)

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -26,7 +26,7 @@ class TestProjectsView(OnyxTestCase):
                 {
                     "project": "testproject",
                     "scope": "admin",
-                    "actions": [action.value for action in Actions],
+                    "actions": [action.label for action in Actions],
                 }
             ],
         )

--- a/onyx/data/urls.py
+++ b/onyx/data/urls.py
@@ -83,6 +83,12 @@ def generate_project_urls(
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
+            r"^history/(?P<climb_id>[cC]-[a-zA-Z0-9]{10})/$",
+            views.HistoryView.as_view(),
+            name=f"projects.{code}.history.climb_id",
+            kwargs={"code": code, "serializer_class": serializer_class},
+        ),
+        re_path(
             r"^identify/(?P<field>[a-zA-Z0-9_]*)/$",
             views.IdentifyView.as_view(),
             name=f"projects.{code}.identify.field",

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -66,6 +66,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
     "internal.middleware.SaveRequest",
 ]
 

--- a/onyx/projects/testproject/project.json
+++ b/onyx/projects/testproject/project.json
@@ -43,7 +43,8 @@
                     "action": [
                         "get",
                         "list",
-                        "filter"
+                        "filter",
+                        "history"
                     ],
                     "fields": [
                         "climb_id",


### PR DESCRIPTION
- `Actions` enum now has `label` and `description` for each action
- Introduced `HistoryView` endpoint enabling access to a changelog of a project record for user's of the project record's site
- Added `simple_history`'s `HistoryRequestMiddleware` to log users who make changes