### PR TITLE
`TypesView`, `LookupsView` and `HistoryView` endpoints

### DIFF
--- a/onyx/accounts/permissions.py
+++ b/onyx/accounts/permissions.py
@@ -120,11 +120,11 @@ class IsProjectApproved(permissions.BasePermission):
         # Check the user's permission to perform action on the project
         project_action_permission = get_permission(
             app_label=project.content_type.app_label,
-            action=view.project_action,
+            action=view.project_action.label,
             code=project.code,
         )
         if not request.user.has_perm(project_action_permission):
-            self.message = f"You do not have permission to {view.project_action} on the {project.name} project."
+            self.message = f"You do not have permission to {view.project_action.description} the {project.name} project."
             return False
 
         # If the user has permission to access and perform the action on the project, then they have permission

--- a/onyx/data/actions.py
+++ b/onyx/data/actions.py
@@ -2,10 +2,16 @@ from enum import Enum
 
 
 class Actions(Enum):
-    GET = "get"
-    LIST = "list"
-    FILTER = "filter"
-    IDENTIFY = "identify"
-    ADD = "add"
-    CHANGE = "change"
-    DELETE = "delete"
+    ACCESS = ("access", "access")
+    GET = ("get", "get a record from")
+    LIST = ("list", "list records from")
+    FILTER = ("filter", "filter records from")
+    HISTORY = ("history", "get a record's history from")
+    IDENTIFY = ("identify", "identify a value from")
+    ADD = ("add", "add a record to")
+    CHANGE = ("change", "change a record on")
+    DELETE = ("delete", "delete a record on")
+
+    def __init__(self, label: str, description: str) -> None:
+        self.label = label
+        self.description = description

--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -11,7 +11,7 @@ from utils.fields import (
 from utils.functions import get_suggestions, get_permission, parse_permission
 from accounts.models import User
 from .models import Choice, Project, ProjectRecord
-from .types import OnyxType, ALL_LOOKUPS
+from .types import OnyxLookup, OnyxType
 
 
 class OnyxField:
@@ -283,7 +283,7 @@ class FieldHandler:
             field_path = "__".join(components[: i + 1])
             lookup = "__".join(components[i + 1 :])
 
-            if lookup in ALL_LOOKUPS:
+            if lookup in OnyxLookup.lookups():
                 # The field is valid, and the lookup is not sus
                 # So we attempt to instantiate the field instance
                 # This could fail if the lookup is not allowed for the given field

--- a/onyx/data/models.py
+++ b/onyx/data/models.py
@@ -11,7 +11,7 @@ from accounts.models import Site, User
 from utils.fields import StrippedCharField, LowerCharField, UpperCharField, SiteField
 from utils.constraints import unique_together
 from simple_history.models import HistoricalRecords
-from .types import ALL_LOOKUPS
+from .types import OnyxLookup
 
 
 class Project(models.Model):
@@ -97,7 +97,7 @@ class BaseRecord(models.Model):
         errors = super().check(**kwargs)
 
         for field in cls._meta.get_fields():
-            if field.name in ALL_LOOKUPS:
+            if field.name in OnyxLookup.lookups():
                 errors.append(
                     checks.Error(
                         f"Field names must not match existing lookups.",

--- a/onyx/data/serializers.py
+++ b/onyx/data/serializers.py
@@ -25,6 +25,48 @@ FIELDS = {
 }
 
 
+class HistoryDiffSerializer(serializers.Serializer):
+    """
+    Serializer for tracked field changes.
+    """
+
+    field = serializers.CharField()
+    type = serializers.CharField()
+
+    def __init__(
+        self,
+        *args,
+        serializer_cls: type[ProjectRecordSerializer],
+        onyx_field: OnyxField,
+        **kwargs,
+    ):
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
+        serlializer_instance = serializer_cls()
+        assert isinstance(serlializer_instance, ProjectRecordSerializer)
+        serializer_fields = serlializer_instance.get_fields()
+
+        if onyx_field.onyx_type in {OnyxType.DATE, OnyxType.DATETIME}:
+            output_format = get_date_output_format(
+                serializer_fields[onyx_field.field_name]
+            )
+            self.fields["from"] = FIELDS[onyx_field.onyx_type](format=output_format)
+            self.fields["to"] = FIELDS[onyx_field.onyx_type](format=output_format)
+        else:
+            self.fields["from"] = FIELDS[onyx_field.onyx_type]()
+            self.fields["to"] = FIELDS[onyx_field.onyx_type]()
+
+
+class IdentifierSerializer(serializers.Serializer):
+    """
+    Serializer for input to the `data.project.identify` endpoint.
+    """
+
+    site = SiteField(default=CurrentUserSiteDefault())
+    value = serializers.CharField()
+
+
 class SummarySerializer(serializers.Serializer):
     """
     Serializer for multi-field count aggregates.
@@ -38,6 +80,9 @@ class SummarySerializer(serializers.Serializer):
         count_name: str,
         **kwargs,
     ):
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
         serlializer_instance = serializer_cls()
         assert isinstance(serlializer_instance, ProjectRecordSerializer)
         serializer_fields = serlializer_instance.get_fields()
@@ -51,16 +96,6 @@ class SummarySerializer(serializers.Serializer):
                 self.fields[field_name] = FIELDS[onyx_field.onyx_type]()
 
         self.fields[count_name] = serializers.IntegerField()
-        super().__init__(*args, **kwargs)
-
-
-class IdentifierSerializer(serializers.Serializer):
-    """
-    Serializer for input to the `data.project.identify` endpoint.
-    """
-
-    site = SiteField(default=CurrentUserSiteDefault())
-    value = serializers.CharField()
 
 
 # https://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields

--- a/onyx/data/spec.py
+++ b/onyx/data/spec.py
@@ -84,9 +84,9 @@ def generate_fields_spec(
             "type": onyx_type.label,
             "required": required,
             "actions": [
-                action.value
+                action.label
                 for action in Actions
-                if action.value in actions_map[field_path]
+                if action.label in actions_map[field_path]
             ],
         }
 
@@ -167,9 +167,9 @@ def generate_fields_spec(
             "type": onyx_type.label,
             "required": onyx_fields[field_path].required,
             "actions": [
-                action.value
+                action.label
                 for action in Actions
-                if action.value in actions_map[field_path]
+                if action.label in actions_map[field_path]
             ],
             # Recursively generate fields spec for the nested serializer
             "fields": generate_fields_spec(

--- a/onyx/data/tests/views/test_choices.py
+++ b/onyx/data/tests/views/test_choices.py
@@ -11,7 +11,7 @@ class TestChoicesView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda field: reverse(
-            "project.testproject.choices",
+            "projects.testproject.choices.field",
             kwargs={"code": self.project.code, "field": field},
         )
 

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -59,7 +59,7 @@ class TestCreateView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject", kwargs={"code": self.project.code}
+            "projects.testproject", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):
@@ -84,7 +84,7 @@ class TestCreateView(OnyxTestCase):
 
         payload = copy.deepcopy(default_payload)
         response = self.client.post(
-            reverse("project.testproject.test", kwargs={"code": self.project.code}),
+            reverse("projects.testproject.test", kwargs={"code": self.project.code}),
             data=payload,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -13,11 +13,11 @@ class TestDeleteView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_fields.py
+++ b/onyx/data/tests/views/test_fields.py
@@ -11,7 +11,7 @@ class TestFieldsView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject.fields", kwargs={"code": self.project.code}
+            "projects.testproject.fields", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -13,7 +13,7 @@ class TestFilterView(OnyxDataTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject", kwargs={"code": self.project.code}
+            "projects.testproject", kwargs={"code": self.project.code}
         )
 
     def _test_filter(self, field, value, qs, lookup="", allow_empty=False):

--- a/onyx/data/tests/views/test_get.py
+++ b/onyx/data/tests/views/test_get.py
@@ -12,11 +12,11 @@ class TestGetView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_history.py
+++ b/onyx/data/tests/views/test_history.py
@@ -1,0 +1,211 @@
+from datetime import timedelta, date
+from rest_framework import status
+from rest_framework.reverse import reverse
+from ..utils import OnyxTestCase, generate_test_data
+from ...exceptions import ClimbIDNotFound
+from ...actions import Actions
+from ...types import OnyxType
+from projects.testproject.models import TestModel
+
+
+class TestHistoryView(OnyxTestCase):
+    def setUp(self):
+        """
+        Create a user with the required permissions and create a test record.
+        """
+
+        super().setUp()
+        self.endpoint = lambda climb_id: reverse(
+            "projects.testproject.history.climb_id",
+            kwargs={"code": self.project.code, "climb_id": climb_id},
+        )
+        response = self.client.post(
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
+            data=next(iter(generate_test_data(n=1))),
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.climb_id = response.json()["data"]["climb_id"]
+
+    def test_basic(self):
+        """
+        Test getting the history of a record by CLIMB ID.
+        """
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 1)
+        self.assertEqual(
+            response.json()["data"]["history"][0]["username"], self.user.username
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+
+    def test_climb_id_not_found(self):
+        """
+        Test getting the history of a record by CLIMB ID that does not exist.
+        """
+
+        prefix, postfix = self.climb_id.split("-")
+        climb_id_not_found = "-".join([prefix, postfix[::-1]])
+        response = self.client.get(self.endpoint(climb_id_not_found))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.json()["messages"]["detail"], ClimbIDNotFound.default_detail
+        )
+
+    def test_change_history(self):
+        """
+        Test getting the history of a record by CLIMB ID after an update.
+        """
+
+        instance = TestModel.objects.get(climb_id=self.climb_id)
+        assert instance.submission_date is not None
+        assert instance.tests is not None
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 2)
+        for diff in response.json()["data"]["history"]:
+            self.assertEqual(diff["username"], self.user.username)
+
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][1]["action"], Actions.CHANGE.label
+        )
+
+        self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        types = {
+            "submission_date": OnyxType.DATE.label,
+            "tests": OnyxType.INTEGER.label,
+            "text_option_2": OnyxType.TEXT.label,
+        }
+        for change in response.json()["data"]["history"][1]["changes"]:
+            from_value = getattr(instance, change["field"])
+            if isinstance(from_value, date):
+                from_value = from_value.strftime("%Y-%m-%d")
+
+            to_value = updated_values[change["field"]]
+            if isinstance(to_value, date):
+                to_value = to_value.strftime("%Y-%m-%d")
+
+            self.assertEqual(change["type"], types[change["field"]])
+            self.assertEqual(change["from"], from_value)
+            self.assertEqual(change["to"], to_value)
+
+    def test_nested_change_history(self):
+        """
+        Test getting the history of a record by CLIMB ID after an update with nested fields.
+        """
+
+        instance = TestModel.objects.get(climb_id=self.climb_id)
+        assert instance.submission_date is not None
+        assert instance.tests is not None
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        updated_values = {
+            "submission_date": instance.submission_date + timedelta(days=1),
+            "tests": instance.tests + 1,
+            "text_option_2": instance.text_option_2 + "!",
+            "records": [
+                {
+                    "test_id": 1,
+                    "test_result": "more_details",
+                },
+                {
+                    "test_id": 2,
+                    "test_result": "more_details",
+                },
+                {
+                    "test_id": 1000,
+                    "test_pass": True,
+                    "test_start": "2024-01",
+                    "test_end": "2024-01",
+                    "score_a": 1,
+                    "score_b": 1,
+                    "test_result": "details",
+                },
+            ],
+        }
+        response = self.client.patch(
+            reverse(
+                "projects.testproject.climb_id",
+                kwargs={"code": self.project.code, "climb_id": self.climb_id},
+            ),
+            data=updated_values,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(self.endpoint(self.climb_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
+        self.assertEqual(len(response.json()["data"]["history"]), 3)
+        for diff in response.json()["data"]["history"]:
+            self.assertEqual(diff["username"], self.user.username)
+
+        self.assertEqual(
+            response.json()["data"]["history"][0]["action"], Actions.ADD.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][1]["action"], Actions.CHANGE.label
+        )
+        self.assertEqual(
+            response.json()["data"]["history"][2]["action"], Actions.CHANGE.label
+        )
+
+        self.assertEqual(len(response.json()["data"]["history"][1]["changes"]), 3)
+        types = {
+            "submission_date": OnyxType.DATE.label,
+            "tests": OnyxType.INTEGER.label,
+            "text_option_2": OnyxType.TEXT.label,
+        }
+        for change in response.json()["data"]["history"][1]["changes"]:
+            from_value = getattr(instance, change["field"])
+            if isinstance(from_value, date):
+                from_value = from_value.strftime("%Y-%m-%d")
+
+            to_value = updated_values[change["field"]]
+            if isinstance(to_value, date):
+                to_value = to_value.strftime("%Y-%m-%d")
+
+            self.assertEqual(change["type"], types[change["field"]])
+            self.assertEqual(change["from"], from_value)
+            self.assertEqual(change["to"], to_value)
+
+        self.assertEqual(len(response.json()["data"]["history"][2]["changes"]), 2)
+        for change in response.json()["data"]["history"][2]["changes"]:
+            self.assertEqual(change["field"], "records")
+            self.assertEqual(change["type"], OnyxType.RELATION.label)
+
+            if change["count"] == 1:
+                self.assertEqual(change["action"], Actions.ADD.label)
+            else:
+                self.assertEqual(change["action"], Actions.CHANGE.label)
+                self.assertEqual(change["count"], 2)

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -15,7 +15,7 @@ class TestIdentifyView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda field: reverse(
-            "project.testproject.identify",
+            "projects.testproject.identify.field",
             kwargs={"code": self.project.code, "field": field},
         )
 
@@ -37,7 +37,7 @@ class TestIdentifyView(OnyxTestCase):
             start=1,
         ):
             result = self.client.post(
-                reverse("project.testproject", kwargs={"code": self.project.code}),
+                reverse("projects.testproject", kwargs={"code": self.project.code}),
                 data=record,
             )
             self.assertEqual(result.status_code, status.HTTP_201_CREATED)
@@ -89,7 +89,7 @@ class TestIdentifyView(OnyxTestCase):
         iterator = iter(generate_test_data(n=2))
         test_record_1 = next(iterator)
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_1,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -99,7 +99,7 @@ class TestIdentifyView(OnyxTestCase):
         test_record_2 = next(iterator)
         test_record_2["run_name"] = test_record_1["run_name"]
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_2,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -127,7 +127,7 @@ class TestIdentifyView(OnyxTestCase):
         iterator = iter(generate_test_data(n=2))
         test_record_1 = next(iterator)
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_1,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -139,7 +139,7 @@ class TestIdentifyView(OnyxTestCase):
         test_record_2["sample_id"] = test_record_1["sample_id"]
         test_record_2["run_name"] = test_record_1["run_name"]
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=test_record_2,
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/onyx/data/tests/views/test_lookups.py
+++ b/onyx/data/tests/views/test_lookups.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase
-from ...types import OnyxType
+from ...types import OnyxLookup, OnyxType
 
 
 class TestLookupsView(OnyxTestCase):
@@ -11,16 +11,25 @@ class TestLookupsView(OnyxTestCase):
         """
 
         super().setUp()
-        self.endpoint = reverse(
-            "project.testproject.lookups", kwargs={"code": self.project.code}
-        )
+        self.endpoint = reverse("projects.lookups")
 
     def test_basic(self):
         """
-        Test retrieval of available lookups for a project.
+        Test retrieval of available lookups.
         """
 
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        lookups = {onyx_type.label: onyx_type.lookups for onyx_type in OnyxType}
+        lookups = [
+            {
+                "lookup": onyx_lookup.label,
+                "description": onyx_lookup.description,
+                "types": [
+                    onyx_type.label
+                    for onyx_type in OnyxType
+                    if onyx_lookup.label in onyx_type.lookups
+                ],
+            }
+            for onyx_lookup in OnyxLookup
+        ]
         self.assertEqual(response.json()["data"], lookups)

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -26,7 +26,7 @@ class TestProjectsView(OnyxTestCase):
                 {
                     "project": "testproject",
                     "scope": "admin",
-                    "actions": [action.value for action in Actions],
+                    "actions": [action.label for action in Actions],
                 }
             ],
         )

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -11,7 +11,7 @@ class TestProjectsView(OnyxTestCase):
         """
 
         super().setUp()
-        self.endpoint = reverse("data.projects")
+        self.endpoint = reverse("projects")
 
     def test_basic(self):
         """

--- a/onyx/data/tests/views/test_query.py
+++ b/onyx/data/tests/views/test_query.py
@@ -15,7 +15,7 @@ class TestQueryView(OnyxDataTestCase):
 
         super().setUp()
         self.endpoint = reverse(
-            "project.testproject.query", kwargs={"code": self.project.code}
+            "projects.testproject.query", kwargs={"code": self.project.code}
         )
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_types.py
+++ b/onyx/data/tests/views/test_types.py
@@ -1,0 +1,32 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from ..utils import OnyxTestCase
+from ...types import OnyxType
+
+
+class TestTypesView(OnyxTestCase):
+    def setUp(self):
+        """
+        Create a user with the required permissions.
+        """
+
+        super().setUp()
+        self.endpoint = reverse("projects.types")
+
+    def test_basic(self):
+        """
+        Test retrieval of available types.
+        """
+
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        types = [
+            {
+                "type": onyx_type.label,
+                "description": onyx_type.description,
+                "lookups": [lookup for lookup in onyx_type.lookups if lookup],
+            }
+            for onyx_type in OnyxType
+        ]
+
+        self.assertEqual(response.json()["data"], types)

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -14,11 +14,11 @@ class TestUpdateView(OnyxTestCase):
 
         super().setUp()
         self.endpoint = lambda climb_id: reverse(
-            "project.testproject.climb_id",
+            "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
         )
         response = self.client.post(
-            reverse("project.testproject", kwargs={"code": self.project.code}),
+            reverse("projects.testproject", kwargs={"code": self.project.code}),
             data=next(iter(generate_test_data(n=1))),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -60,7 +60,7 @@ class TestUpdateView(OnyxTestCase):
         }
         response = self.client.patch(
             reverse(
-                "project.testproject.test.climb_id",
+                "projects.testproject.test.climb_id",
                 kwargs={"code": self.project.code, "climb_id": self.climb_id},
             ),
             data=updated_values,

--- a/onyx/data/types.py
+++ b/onyx/data/types.py
@@ -1,136 +1,261 @@
 from enum import Enum
 
 
+class OnyxLookup(Enum):
+    EXACT = (
+        "exact",
+        "The field's value must be equal to the query value.",
+    )
+    NE = (
+        "ne",
+        "The field's value must not be equal to the query value.",
+    )
+    IN = (
+        "in",
+        "The field's value must be in the list of query values.",
+    )
+    NOTIN = (
+        "notin",
+        "The field's value must not be in the list of query values.",
+    )
+    CONTAINS = (
+        "contains",
+        "The field's value must contain the query value.",
+    )
+    STARTSWITH = (
+        "startswith",
+        "The field's value must start with the query value.",
+    )
+    ENDSWITH = (
+        "endswith",
+        "The field's value must end with the query value.",
+    )
+    IEXACT = (
+        "iexact",
+        "The field's value must be equal to the query value, ignoring case.",
+    )
+    ICONTAINS = (
+        "icontains",
+        "The field's value must contain the query value, ignoring case.",
+    )
+    ISTARTSWITH = (
+        "istartswith",
+        "The field's value must start with the query value, ignoring case.",
+    )
+    IENDSWITH = (
+        "iendswith",
+        "The field's value must end with the query value, ignoring case.",
+    )
+    LENGTH = (
+        "length",
+        "The length of the field's value must be equal to the query value.",
+    )
+    LENGTH_IN = (
+        "length__in",
+        "The length of the field's value must be in the list of query values.",
+    )
+    LENGTH_RANGE = (
+        "length__range",
+        "The length of the field's value must be in the range of query values.",
+    )
+    LT = (
+        "lt",
+        "The field's value must be less than the query value.",
+    )
+    LTE = (
+        "lte",
+        "The field's value must be less than or equal to the query value.",
+    )
+    GT = (
+        "gt",
+        "The field's value must be greater than the query value.",
+    )
+    GTE = (
+        "gte",
+        "The field's value must be greater than or equal to the query value.",
+    )
+    RANGE = (
+        "range",
+        "The field's value must be in the range of query values.",
+    )
+    ISO_YEAR = (
+        "iso_year",
+        "The ISO 8601 week-numbering year of the field's value must be equal to the query value.",
+    )
+    ISO_YEAR_IN = (
+        "iso_year__in",
+        "The ISO 8601 week-numbering year of the field's value must be in the list of query values.",
+    )
+    ISO_YEAR_RANGE = (
+        "iso_year__range",
+        "The ISO 8601 week-numbering year of the field's value must be in the range of query values.",
+    )
+    WEEK = (
+        "week",
+        "The ISO 8601 week number of the field's value must be equal to the query value.",
+    )
+    WEEK_IN = (
+        "week__in",
+        "The ISO 8601 week number of the field's value must be in the list of query values.",
+    )
+    WEEK_RANGE = (
+        "week__range",
+        "The ISO 8601 week number of the field's value must be in the range of query values.",
+    )
+    ISNULL = (
+        "isnull",
+        "The field's value must be empty.",
+    )
+
+    def __init__(self, label, description) -> None:
+        self.label = label
+        self.description = description
+
+    @classmethod
+    def lookups(cls):
+        """
+        Returns the set of all lookup labels.
+        """
+
+        return {""} | {lookup.label for lookup in cls}
+
+
 class OnyxType(Enum):
     TEXT = (
         "text",
+        "A string of characters.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "contains",
-            "startswith",
-            "endswith",
-            "iexact",
-            "icontains",
-            "istartswith",
-            "iendswith",
-            "length",
-            "length__in",
-            "length__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.CONTAINS.label,
+            OnyxLookup.STARTSWITH.label,
+            OnyxLookup.ENDSWITH.label,
+            OnyxLookup.IEXACT.label,
+            OnyxLookup.ICONTAINS.label,
+            OnyxLookup.ISTARTSWITH.label,
+            OnyxLookup.IENDSWITH.label,
+            OnyxLookup.LENGTH.label,
+            OnyxLookup.LENGTH_IN.label,
+            OnyxLookup.LENGTH_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     CHOICE = (
         "choice",
+        "A restricted set of options.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     INTEGER = (
         "integer",
+        "A whole number.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DECIMAL = (
         "decimal",
+        "A decimal number.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DATE = (
         "date",
+        "A date.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "iso_year",
-            "iso_year__in",
-            "iso_year__range",
-            "week",
-            "week__in",
-            "week__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISO_YEAR.label,
+            OnyxLookup.ISO_YEAR_IN.label,
+            OnyxLookup.ISO_YEAR_RANGE.label,
+            OnyxLookup.WEEK.label,
+            OnyxLookup.WEEK_IN.label,
+            OnyxLookup.WEEK_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     DATETIME = (
         "datetime",
+        "A date and time.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "lt",
-            "lte",
-            "gt",
-            "gte",
-            "range",
-            "iso_year",
-            "iso_year__in",
-            "iso_year__range",
-            "week",
-            "week__in",
-            "week__range",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.LT.label,
+            OnyxLookup.LTE.label,
+            OnyxLookup.GT.label,
+            OnyxLookup.GTE.label,
+            OnyxLookup.RANGE.label,
+            OnyxLookup.ISO_YEAR.label,
+            OnyxLookup.ISO_YEAR_IN.label,
+            OnyxLookup.ISO_YEAR_RANGE.label,
+            OnyxLookup.WEEK.label,
+            OnyxLookup.WEEK_IN.label,
+            OnyxLookup.WEEK_RANGE.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     BOOLEAN = (
         "bool",
+        "A true or false value.",
         [
             "",
-            "exact",
-            "ne",
-            "in",
-            "notin",
-            "isnull",
+            OnyxLookup.EXACT.label,
+            OnyxLookup.NE.label,
+            OnyxLookup.IN.label,
+            OnyxLookup.NOTIN.label,
+            OnyxLookup.ISNULL.label,
         ],
     )
     RELATION = (
         "relation",
+        "A link to a row, or multiple rows, in another table.",
         [
-            "isnull",
+            OnyxLookup.ISNULL.label,
         ],
     )
 
-    def __init__(self, label, lookups) -> None:
+    def __init__(self, label, description, lookups) -> None:
         self.label = label
+        self.description = description
         self.lookups = lookups
-
-
-ALL_LOOKUPS = set(lookup for onyx_type in OnyxType for lookup in onyx_type.lookups)

--- a/onyx/data/urls.py
+++ b/onyx/data/urls.py
@@ -83,6 +83,12 @@ def generate_project_urls(
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
+            r"^history/(?P<climb_id>[cC]-[a-zA-Z0-9]{10})/$",
+            views.HistoryView.as_view(),
+            name=f"projects.{code}.history.climb_id",
+            kwargs={"code": code, "serializer_class": serializer_class},
+        ),
+        re_path(
             r"^identify/(?P<field>[a-zA-Z0-9_]*)/$",
             views.IdentifyView.as_view(),
             name=f"projects.{code}.identify.field",

--- a/onyx/data/urls.py
+++ b/onyx/data/urls.py
@@ -8,7 +8,17 @@ urlpatterns = [
     path(
         "",
         views.ProjectsView.as_view(),
-        name="data.projects",
+        name="projects",
+    ),
+    path(
+        "types/",
+        views.TypesView.as_view(),
+        name=f"projects.types",
+    ),
+    path(
+        "lookups/",
+        views.LookupsView.as_view(),
+        name=f"projects.lookups",
     ),
 ]
 
@@ -29,9 +39,9 @@ def generate_project_urls(
 
     return [
         path(
-            r"",
+            "",
             views.ProjectRecordsViewSet.as_view({"post": "create", "get": "list"}),
-            name=f"project.{code}",
+            name=f"projects.{code}",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
@@ -39,49 +49,43 @@ def generate_project_urls(
             views.ProjectRecordsViewSet.as_view(
                 {"get": "retrieve", "patch": "partial_update", "delete": "destroy"}
             ),
-            name=f"project.{code}.climb_id",
+            name=f"projects.{code}.climb_id",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
-        re_path(
-            r"^test/$",
+        path(
+            "test/",
             views.ProjectRecordsViewSet.as_view({"post": "create"}),
-            name=f"project.{code}.test",
+            name=f"projects.{code}.test",
             kwargs={"code": code, "serializer_class": serializer_class, "test": True},
         ),
         re_path(
             r"^test/(?P<climb_id>[cC]-[a-zA-Z0-9]{10})/$",
             views.ProjectRecordsViewSet.as_view({"patch": "partial_update"}),
-            name=f"project.{code}.test.climb_id",
+            name=f"projects.{code}.test.climb_id",
             kwargs={"code": code, "serializer_class": serializer_class, "test": True},
         ),
-        re_path(
-            r"^query/$",
+        path(
+            "query/",
             views.ProjectRecordsViewSet.as_view({"post": "list"}),
-            name=f"project.{code}.query",
+            name=f"projects.{code}.query",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
-        re_path(
-            r"^fields/$",
+        path(
+            "fields/",
             views.FieldsView.as_view(),
-            name=f"project.{code}.fields",
-            kwargs={"code": code, "serializer_class": serializer_class},
-        ),
-        re_path(
-            r"^lookups/$",
-            views.LookupsView.as_view(),
-            name=f"project.{code}.lookups",
+            name=f"projects.{code}.fields",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
             r"^choices/(?P<field>[a-zA-Z0-9_]*)/$",
             views.ChoicesView.as_view(),
-            name=f"project.{code}.choices",
+            name=f"projects.{code}.choices.field",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
         re_path(
             r"^identify/(?P<field>[a-zA-Z0-9_]*)/$",
             views.IdentifyView.as_view(),
-            name=f"project.{code}.identify",
+            name=f"projects.{code}.identify.field",
             kwargs={"code": code, "serializer_class": serializer_class},
         ),
     ]

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -66,6 +66,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
     "internal.middleware.SaveRequest",
 ]
 

--- a/onyx/projects/testproject/project.json
+++ b/onyx/projects/testproject/project.json
@@ -43,7 +43,8 @@
                     "action": [
                         "get",
                         "list",
-                        "filter"
+                        "filter",
+                        "history"
                     ],
                     "fields": [
                         "climb_id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.15.7"
+version = "0.16.0"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- `Actions` now have a `label` and `description`.
- Introduced `OnyxLookup` enum.
- Added views for types, lookups and obtaining history of a project record.
- Renamed url scheme (names with prefix `project` changed to have consistent `projects` prefix).