### PR TITLE
Improved pydantic validation, refactored query building process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.DS_Store
 .venv
 .env
 .coverage

--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -31,6 +31,7 @@ class OnyxField:
         "description",
         "choices",
         "lookup",
+        "value",
     )
 
     def __init__(
@@ -40,6 +41,7 @@ class OnyxField:
         field_path: str,
         lookup: str,
         allow_lookup: bool = False,
+        value: Any = None,
     ):
         self.project = project
         self.field_model = field_model
@@ -120,6 +122,7 @@ class OnyxField:
             raise exceptions.ValidationError(suggestions)
 
         self.lookup = lookup
+        self.value = value
 
 
 class FieldHandler:

--- a/onyx/data/query.py
+++ b/onyx/data/query.py
@@ -1,194 +1,293 @@
+from __future__ import annotations
 import operator
 import functools
-from typing import Dict, List, Any
-from django.db.models import Q, Model
+from enum import Enum
+from typing import Any
+from typing_extensions import Annotated
+import pydantic
+from django.conf import settings
+from django.db.models import Q
 from rest_framework import exceptions
+from utils.functions import pydantic_to_drf_error
 from .filters import OnyxFilter
-from .fields import OnyxField
+from .fields import FieldHandler
+from .types import OnyxLookup
 
 
-class QueryAtom:
+class QuerySymbol(Enum):
+    ATOM = "Atom"
+    AND = "&"
+    OR = "|"
+    XOR = "^"
+    NOT = "~"
+
+
+def get_discriminator_value(obj):
+    if isinstance(obj, dict):
+        key = next(iter(obj.keys()), None)
+
+        try:
+            return QuerySymbol(key).value
+        except ValueError:
+            pass
+
+    return QuerySymbol.ATOM.value
+
+
+class Atom(pydantic.RootModel):
     """
-    Class for representing the most basic component of a query; a single key-value pair.
+    The most basic query element.
     """
 
-    __slots__ = "key", "value", "exclude", "default"
-
-    def __init__(self, key, value, exclude=False, default=None):
-        self.key = key
-        self.value = value
-        self.exclude = exclude
-        self.default = default
+    root: dict[str, str | int | float | bool | None] = pydantic.Field(
+        min_length=1, max_length=1
+    )
 
 
-# TODO: Improve validation or find better ways e.g. JSON Schema?
-def validate_data(func):
-    def wrapped(data, *args, **kwargs):
-        if not isinstance(data, dict):
-            raise exceptions.ValidationError(
-                {
-                    "detail": f"Expected dictionary when parsing query but received type: {type(data)}"
-                }
+class AND(pydantic.BaseModel):
+    """
+    Logical AND operation.
+    """
+
+    op: list[Query] = pydantic.Field(
+        alias=QuerySymbol.AND.value,
+        min_length=1,
+        max_length=settings.ONYX_CONFIG["MAX_ITERABLE_INPUT"],
+    )
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class OR(pydantic.BaseModel):
+    """
+    Logical OR operation.
+    """
+
+    op: list[Query] = pydantic.Field(
+        alias=QuerySymbol.OR.value,
+        min_length=1,
+        max_length=settings.ONYX_CONFIG["MAX_ITERABLE_INPUT"],
+    )
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class XOR(pydantic.BaseModel):
+    """
+    Logical XOR operation.
+    """
+
+    op: list[Query] = pydantic.Field(
+        alias=QuerySymbol.XOR.value,
+        min_length=1,
+        max_length=settings.ONYX_CONFIG["MAX_ITERABLE_INPUT"],
+    )
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class NOT(pydantic.BaseModel):
+    """
+    Logical NOT operation.
+    """
+
+    op: Query = pydantic.Field(alias=QuerySymbol.NOT.value)
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class Query(pydantic.RootModel):
+    """
+    Generic structure for a query: can be an atom or a logical operation.
+    """
+
+    root: Annotated[
+        Annotated[Atom, pydantic.Tag(QuerySymbol.ATOM.value)]
+        | Annotated[AND, pydantic.Tag(QuerySymbol.AND.value)]
+        | Annotated[OR, pydantic.Tag(QuerySymbol.OR.value)]
+        | Annotated[XOR, pydantic.Tag(QuerySymbol.XOR.value)]
+        | Annotated[NOT, pydantic.Tag(QuerySymbol.NOT.value)],
+        pydantic.Discriminator(get_discriminator_value),
+    ]
+
+
+class QueryBuilder:
+    __slots__ = "data", "field_handler", "onyx_fields", "errors"
+
+    def __init__(self, data: dict[str, Any], handler: FieldHandler) -> None:
+        """
+        Initialises the QueryBuilder object with the provided data and field handler.
+
+        Args:
+            data: The data to build the query from.
+            handler: The field handler to use for resolving fields.
+        """
+
+        self.field_handler = handler
+        self.onyx_fields = []
+        self.errors = {}
+
+        try:
+            self.data = Query.model_validate(data).model_dump(
+                mode="python", by_alias=True
             )
+            self.validate_fields(self.data)
+            self.validate_field_values()
+        except pydantic.ValidationError as e:
+            for name, err in pydantic_to_drf_error(e).args[0].items():
+                self.errors.setdefault(name, []).extend(err)
 
-        if len(data.items()) != 1:
-            raise exceptions.ValidationError(
-                {"detail": "Dictionary within query is not a single key-value pair"}
-            )
+    def validate_fields(self, data: dict[str, Any]) -> None:
+        """
+        Validates the fields in the provided data.
+
+        Args:
+            data: The data to validate.
+        """
 
         key, value = next(iter(data.items()))
 
-        if key in {"&", "|", "^"}:
-            if not isinstance(value, list):
-                raise exceptions.ValidationError(
-                    {
-                        "detail": f"Expected list when parsing query but received type: {type(value)}"
-                    }
-                )
-            if len(value) < 1:
-                raise exceptions.ValidationError(
-                    {"detail": "List within query must have at least one item"}
-                )
+        if key in {
+            QuerySymbol.AND.value,
+            QuerySymbol.OR.value,
+            QuerySymbol.XOR.value,
+        }:
+            for k_v in value:
+                self.validate_fields(k_v)
 
-        return func(data, *args, **kwargs)
+        elif key == QuerySymbol.NOT.value:
+            self.validate_fields(value)
 
-    return wrapped
-
-
-@validate_data
-def make_atoms(data: Dict[str, Any]) -> List[QueryAtom]:
-    """
-    Traverses the provided `data` and replaces request values with `QueryAtom` objects.
-    Returns a list of these `QueryAtom` objects.
-    """
-
-    key, value = next(iter(data.items()))
-
-    if key in {"&", "|", "^"}:
-        atoms = [make_atoms(k_v) for k_v in value]
-        return functools.reduce(operator.add, atoms)
-
-    elif key == "~":
-        return make_atoms(value)
-
-    else:
-        # Initialise QueryAtom object
-        # The value is turned into a str for the filterset form.
-        # This is what the filterset is built to handle; it attempts to decode these strs and returns errors if it fails.
-        # If we don't turn these values into strs, the filterset can crash
-        # e.g. If you pass a list, it assumes it is a str, and tries to split by a comma -> ERROR
-        atom = QueryAtom(key, str(value) if value is not None else "")
-
-        # Replace the data value with the QueryAtom object
-        data[key] = atom
-
-        # Now return the QueryAtom object
-        # This is done so that it's easy to modify the QueryAtom objects
-        # While also preserving the original structure of the query
-        return [atom]
-
-
-@validate_data
-def make_query(data: Dict[str, Any]) -> Q:
-    """
-    Traverses the provided `data` and forms the corresponding Q object.
-    """
-
-    key, value = next(iter(data.items()))
-    operators = {"&": operator.and_, "|": operator.or_, "^": operator.xor}
-
-    if key in operators:
-        q_objects = [make_query(k_v) for k_v in value]
-        return functools.reduce(operators[key], q_objects)
-
-    elif key == "~":
-        return ~make_query(value)
-
-    else:
-        # Base case: a QueryAtom to filter on
-        # 'value' here is a QueryAtom object
-        # That by this point, should have been cleaned and corrected to work in a query
-        if value.default:
-            q = value.default
         else:
-            q = Q(**{value.key: value.value})
+            try:
+                # Initialise OnyxField object
+                # Lookups are allowed for filter fields
+                onyx_field = self.field_handler.resolve_field(key, allow_lookup=True)
 
-        if value.exclude:
-            q = ~q
-        return q
+                # The value is turned into a str for the filterset form.
+                # This is what the filterset is built to handle; it attempts to decode these strs and returns errors if it fails.
+                # If we don't turn these values into strs, the filterset can crash
+                # e.g. If you pass a list, it assumes it is a str, and tries to split by a comma -> ERROR
+                onyx_field.value = str(value) if value is not None else ""
 
+                # Replace the data value with the OnyxField object
+                data[key] = onyx_field
 
-def validate_atoms(
-    model: type[Model],
-    atoms: List[QueryAtom],
-    onyx_fields: Dict[str, OnyxField],
-) -> None:
-    """
-    Use the `OnyxFilter` to validate and clean the provided list of `atoms`.
-    """
+                # Now append the OnyxField object to the onyx_fields list
+                # This is done so that it's easy to modify the OnyxField objects
+                # While also preserving the original structure of the query
+                self.onyx_fields.append(onyx_field)
+            except exceptions.ValidationError as e:
+                self.errors.setdefault(key, []).append(e.args[0])
 
-    # Construct a list of dictionaries from the atoms
-    # Each of these dictionaries will be passed to the OnyxFilter
-    # The OnyxFilter is then used to validate and clean the inputs
-    # Until we construct the query, it doesn't matter how fields are related in the query (i.e. AND, OR, etc)
-    # All that matters is that the individual fields (and lookups) with their values are valid
-    layers = [{}]
+    def is_valid(self) -> bool:
+        """
+        Returns True if the query data is valid, False otherwise.
+        """
 
-    for atom in atoms:
-        # Place the QueryAtom in the first dictionary where the key is not present
-        # If we reach the end with no placement, create a new dictionary and add it in there
-        for layer in layers:
-            if atom.key not in layer:
-                layer[atom.key] = atom
-                break
-        else:
-            layers.append({atom.key: atom})
+        return not self.errors
 
-    # Use a filterset, applied to each layer, to validate the data
-    # Slightly cursed, but it works
-    errors = {}
-    for layer in layers:
-        fs = OnyxFilter(
-            onyx_fields,
-            data={k: v.value for k, v in layer.items()},
-            queryset=model.objects.none(),
+    def validate_field_values(self) -> None:
+        """
+        Validates the values of the fields in the query data.
+        """
+
+        # Each OnyxField object is mapped to a unique key
+        onyx_fields_map = {}
+        for i, onyx_field in enumerate(self.onyx_fields):
+            key = "-".join([str(i), onyx_field.field_path, onyx_field.lookup])
+            onyx_fields_map[key] = onyx_field
+
+        # Use a filterset to validate the data
+        # Slightly cursed, but it works
+        # Until we construct the query, it doesn't matter how fields are related in the query (i.e. AND, OR, etc)
+        # All that matters is that the individual fields (and lookups) with their values are valid
+        filterset = OnyxFilter(
+            onyx_fields_map,
+            data={key: onyx_field.value for key, onyx_field in onyx_fields_map.items()},
+            queryset=self.field_handler.model.objects.none(),
         )
 
-        if fs.is_valid():
-            # Update the QueryAtom objects with their cleaned values
-            for k, atom in layer.items():
-                atom.value = fs.form.cleaned_data[k]
-
-                # Handle manual overrides for Q objects of certain lookups
-                if onyx_fields[k].lookup == "ne":
-                    if atom.value is None:
-                        atom.key = f"{onyx_fields[k].field_path}__isnull"
-                        atom.value = False
-                    else:
-                        atom.key = onyx_fields[k].field_path
-                        atom.exclude = True
-
-                elif onyx_fields[k].lookup == "in":
-                    if None in atom.value:
-                        atom.value = [v for v in atom.value if v is not None]
-                        atom.default = Q(**{atom.key: atom.value}) | Q(
-                            **{f"{onyx_fields[k].field_path}__isnull": True}
-                        )
-
-                elif onyx_fields[k].lookup == "notin":
-                    atom.key = f"{onyx_fields[k].field_path}__in"
-                    atom.exclude = True
-
-                    if None in atom.value:
-                        atom.value = [v for v in atom.value if v is not None]
-                        atom.default = Q(**{atom.key: atom.value}) | Q(
-                            **{f"{onyx_fields[k].field_path}__isnull": True}
-                        )
-
+        if filterset.is_valid():
+            # Update the OnyxField objects with their cleaned values
+            for key, onyx_field in onyx_fields_map.items():
+                onyx_field.value = filterset.form.cleaned_data[key]
         else:
             # If not valid, record the errors
-            for field_name, field_errors in fs.errors.items():
-                errors.setdefault(field_name, []).extend(field_errors)
+            for key, errors in filterset.errors.items():
+                onyx_field = onyx_fields_map[key]
 
-    if errors:
-        raise exceptions.ValidationError(errors)
+                if onyx_field.lookup:
+                    filter_path = f"{onyx_field.field_path}__{onyx_field.lookup}"
+                else:
+                    filter_path = onyx_field.field_path
+
+                self.errors.setdefault(filter_path, []).extend(errors)
+
+    def _build(self, data: dict[str, Any]) -> Q:
+        """
+        Recursively builds a Q object from the provided query data.
+
+        Args:
+            data: The data to build the Q object from.
+
+        Returns:
+            The Q object built from the provided data.
+        """
+
+        key, value = next(iter(data.items()))
+
+        operators = {
+            QuerySymbol.AND.value: operator.and_,
+            QuerySymbol.OR.value: operator.or_,
+            QuerySymbol.XOR.value: operator.xor,
+        }
+
+        if key in operators:
+            q_objects = [self._build(k_v) for k_v in value]
+            return functools.reduce(operators[key], q_objects)
+
+        elif key == QuerySymbol.NOT.value:
+            return ~self._build(value)
+
+        else:
+            # Base case: 'value' here is an OnyxField object
+            # That by this point, should have been cleaned and corrected to work in a query
+            # Handle manual overrides for Q objects of certain lookups
+            if value.lookup == OnyxLookup.NE.label:
+                if value.value is None:
+                    return Q(
+                        **{f"{value.field_path}__{OnyxLookup.ISNULL.label}": False}
+                    )
+                else:
+                    return ~Q(**{value.field_path: value.value})
+
+            elif value.lookup == OnyxLookup.IN.label and None in value.value:
+                values = [v for v in value.value if v is not None]
+                return Q(**{f"{value.field_path}__{value.lookup}": values}) | Q(
+                    **{f"{value.field_path}__{OnyxLookup.ISNULL.label}": True}
+                )
+
+            elif value.lookup == OnyxLookup.NOTIN.label:
+                if None in value.value:
+                    values = [v for v in value.value if v is not None]
+                    return ~(
+                        Q(**{f"{value.field_path}__{OnyxLookup.IN.label}": values})
+                        | Q(**{f"{value.field_path}__{OnyxLookup.ISNULL.label}": True})
+                    )
+                else:
+                    return ~Q(
+                        **{f"{value.field_path}__{OnyxLookup.IN.label}": value.value}
+                    )
+
+            else:
+                if value.lookup:
+                    filter_path = f"{value.field_path}__{value.lookup}"
+                else:
+                    filter_path = value.field_path
+
+                return Q(**{filter_path: value.value})
+
+    def build(self) -> Q:
+        """
+        Builds a Q object from the provided query data.
+        """
+
+        assert not self.errors, "Errors must be resolved before building query"
+        return self._build(self.data)

--- a/onyx/data/query.py
+++ b/onyx/data/query.py
@@ -176,13 +176,6 @@ class QueryBuilder:
             except exceptions.ValidationError as e:
                 self.errors.setdefault(key, []).append(e.args[0])
 
-    def is_valid(self) -> bool:
-        """
-        Returns True if the query data is valid, False otherwise.
-        """
-
-        return not self.errors
-
     def validate_field_values(self) -> None:
         """
         Validates the values of the fields in the query data.
@@ -219,6 +212,13 @@ class QueryBuilder:
                     filter_path = onyx_field.field_path
 
                 self.errors.setdefault(filter_path, []).extend(errors)
+
+    def is_valid(self) -> bool:
+        """
+        Returns True if the query data is valid, False otherwise.
+        """
+
+        return not self.errors
 
     def _build(self, data: dict[str, Any]) -> Q:
         """

--- a/onyx/data/serializers.py
+++ b/onyx/data/serializers.py
@@ -48,6 +48,8 @@ class HistoryDiffSerializer(serializers.Serializer):
         serializer_fields = serlializer_instance.get_fields()
 
         if onyx_field.onyx_type in {OnyxType.DATE, OnyxType.DATETIME}:
+            # TODO: Currently this does not work for nested date fields
+            # Ideal solution would be to have serializer field instances attached to OnyxField objects
             output_format = get_date_output_format(
                 serializer_fields[onyx_field.field_name]
             )

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -674,15 +674,15 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
         # Validate the query data
         if data:
             query = QueryBuilder(data, filter_handler)
-
-            if not query.is_valid():
+            if query.is_valid():
+                # If a summary is being carried out on one or more fields
+                # then any field involved in filtering will also be included
+                for onyx_field in query.onyx_fields:
+                    if onyx_field.field_path not in summary_fields:
+                        summary_fields[onyx_field.field_path] = onyx_field
+            else:
                 for filter_name, errs in query.errors.items():
                     errors.setdefault(filter_name, []).extend(errs)
-
-            # If a summary is being carried out on one or more fields
-            # then any field involved in filtering will also be included
-            for onyx_field in query.onyx_fields:
-                summary_fields[onyx_field.field_path] = onyx_field
         else:
             query = None
 

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -202,3 +202,10 @@ LOGGING = {
 SILENCED_SYSTEM_CHECKS = [
     "rest_framework.W001",  # REST Framework Paginator page size is set but no default paginator
 ]
+
+ONYX_CONFIG = {
+    # The maximum number of items that can be submitted within a request body iterable
+    "MAX_ITERABLE_INPUT": 100,
+    # The maximum number of items that can be returned within a summary
+    "MAX_SUMMARY_OUTPUT": 100000,
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.16.0"
+version = "0.16.1"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Improved specificity of `RequestBody` pydantic errors by using a discriminated union. 
- Introduced `ONYX_CONFIG` settings with:
   - `MAX_ITERABLE_INPUT`: sets a max number of items in a request body list / max number of keys in a request body dictionary. Works on arbitrarily nested items. Default is set to `100`.
   - `MAX_SUMMARY_OUTPUT`: max number of items output in a summary call. Default is `100000`.
- Replaced `make_atoms`, `validate_atoms`, `make_query` functions with`QueryBuilder` class that handles each operation under a simple interface, and coerces errors where possible into a single error dictionary.
- Replaced `QueryAtom` class with `OnyxField`, used by the `QueryBuilder` to make `Q` objects.
- Added pydantic to validate the structure of a query before the fields/values are validated. 
- Added util function `pydantic_to_drf_error`.
