### PR TITLE
Bug fixes 

### DIFF
--- a/onyx/data/query.py
+++ b/onyx/data/query.py
@@ -276,6 +276,14 @@ class QueryBuilder:
                         **{f"{value.field_path}__{OnyxLookup.IN.label}": value.value}
                     )
 
+            elif value.lookup == OnyxLookup.ISNULL.label:
+                if value.value:
+                    return Q(**{f"{value.field_path}__{value.lookup}": True})
+                else:
+                    # Using an exclude here causes Django to generate a much more efficient query for relational fields
+                    # https://stackoverflow.com/questions/7171041/what-does-it-mean-by-select-1-from-table
+                    return ~Q(**{f"{value.field_path}__{value.lookup}": True})
+
             else:
                 if value.lookup:
                     filter_path = f"{value.field_path}__{value.lookup}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.16.4"
+version = "0.16.5"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Fixed slow queries for relation field with `isnull` lookup and `False` value. This was fixed by introducing an override to the `Q` object: instead of running `Q(<field>__isnull=False)`, we now run `~Q(<field>__isnull=True)`. The SQL generated by Django for the latter is much more efficient: https://stackoverflow.com/questions/7171041/what-does-it-mean-by-select-1-from-table
- Fixed bug introduced by the `QueryBuilder` where relational filter fields weren't being rejected on a summarise, which caused an ISE.