### PR TITLE
Speedup for summarise with filtering on a related table

### DIFF
--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -712,7 +712,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
             raise exceptions.ValidationError(errors)
 
         # Initial queryset
-        qs = init_project_queryset(
+        init_qs = init_project_queryset(
             model=self.model,
             user=request.user,
             fields=self.handler.get_fields(),
@@ -726,7 +726,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
         )
 
         # Prefetch nested fields returned in response
-        qs = prefetch_nested(qs, unflatten_fields(fields))
+        qs = prefetch_nested(init_qs, unflatten_fields(fields))
 
         # Q objects for filtering the queryset
         q_objects = []
@@ -806,7 +806,7 @@ class ProjectRecordsViewSet(ViewSetMixin, ProjectAPIView):
                 # or the number of rows in the main table that have no related rows.
                 qs = qs.filter(
                     id__in=Subquery(
-                        qs.filter(**{f"{relation}__isnull": False}).values("id")
+                        init_qs.filter(**{f"{relation}__isnull": False}).values("id")
                     )
                 )
                 count_name = f"{relation}__count"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.16.8"
+version = "0.16.9"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- This pull request introduces a simple fix to improve performance of `summarise` when combined with filtering of fields from a related table.
- When summarising on fields from a related table `x`, any project records that do not have related rows in `x`  are first excluded. Originally, this was done by grabbing ids for any project records that satisfied the existing `qs`, as well as having `x__isnull=false`, within a `Subquery`. However, when the existing `qs` is an intensive filter of the related table `x`, this `Subquery` can introduce performance problems for the summary.
- The fix was to change the id-grabbing in the `Subquery` to just grab ids for project records that satisfy the base queryset, but not worry about user filters. The `Subquery` doesn't need to satisfy the user query, it just needs to provide a list of ids with `x__isnull=false` that the actual query can match against.
- We use the base queryset from `init_project_queryset` because filtering on `is_suppressed`, `is_published` etc doesn't seem to introduce huge time costs in practice, but may save noticeably on the amount of ids being checked against. May change this in the future.
- Drawbacks of this are that the number of ids returned by the `Subquery` for the main query to match against could increase significantly, as the user filters are no longer applied. However, with the projects that onyx is currently being used for, the number of items in related tables vastly outsizes the number of project records, so this approach is currently preferable. 