### PR TITLE
Test improvements

### DIFF
--- a/onyx/accounts/tests.py
+++ b/onyx/accounts/tests.py
@@ -6,6 +6,10 @@ from internal.models import RequestHistory
 class TestProfileView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse("accounts.profile")
 
     def test_basic(self):
@@ -15,14 +19,20 @@ class TestProfileView(OnyxTestCase):
 
         response = self.client.get(self.endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["data"]["username"], self.user.username)
-        self.assertEqual(response.json()["data"]["site"], self.user.site.code)
-        self.assertEqual(response.json()["data"]["email"], self.user.email)
+        self.assertEqual(
+            response.json()["data"]["username"], self.analyst_user.username
+        )
+        self.assertEqual(response.json()["data"]["site"], self.analyst_user.site.code)
+        self.assertEqual(response.json()["data"]["email"], self.analyst_user.email)
 
 
 class TestActivityView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse("accounts.activity")
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_choices.py
+++ b/onyx/data/tests/views/test_choices.py
@@ -6,6 +6,10 @@ from ..utils import OnyxTestCase
 class TestChoicesView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = lambda field: reverse(
             "projects.testproject.choices.field",
             kwargs={"code": self.project.code, "field": field},

--- a/onyx/data/tests/views/test_create.py
+++ b/onyx/data/tests/views/test_create.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.serializers import BooleanField
-from ..utils import OnyxTestCase, _test_record
+from ..utils import OnyxTestCase
 from projects.testproject.models import TestModel, TestModelRecord
 
 
@@ -53,6 +53,10 @@ default_payload = {
 class TestCreateView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the admin user
+        self.client.force_authenticate(self.admin_user)  # type: ignore
+
         self.endpoint = reverse(
             "projects.testproject", kwargs={"code": self.project.code}
         )
@@ -70,7 +74,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
     def test_basic_test(self):
         """
@@ -127,7 +131,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
     def test_unpermissioned_viewable_field(self):
         """
@@ -228,7 +232,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
     def test_conditional_value_required_fields(self):
         """
@@ -253,7 +257,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
     def test_nested_conditional_value_required_fields(self):
         """
@@ -278,7 +282,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
     def test_unique_together(self):
         """
@@ -295,7 +299,7 @@ class TestCreateView(OnyxTestCase):
         default_sample_id_identifier = payload["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
         default_run_name_identifier = payload["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
         payload["sample_id"] = "sample-2345"
@@ -306,7 +310,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
         payload["run_name"] = "run-2"
@@ -317,7 +321,7 @@ class TestCreateView(OnyxTestCase):
         instance = TestModel.objects.get(climb_id=response.json()["data"]["climb_id"])
         payload["sample_id"] = response.json()["data"]["sample_id"]
         payload["run_name"] = response.json()["data"]["run_name"]
-        _test_record(self, payload, instance, created=True)
+        self.assertEqualRecords(payload, instance, created=True)
 
         payload = copy.deepcopy(default_payload)
         response = self.client.post(self.endpoint, data=payload)
@@ -523,7 +527,7 @@ class TestCreateView(OnyxTestCase):
             )
             payload["sample_id"] = response.json()["data"]["sample_id"]
             payload["run_name"] = response.json()["data"]["run_name"]
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_text in bad_texts:
@@ -572,7 +576,7 @@ class TestCreateView(OnyxTestCase):
             )
             payload["sample_id"] = response.json()["data"]["sample_id"]
             payload["run_name"] = response.json()["data"]["run_name"]
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_choice in bad_choices:
@@ -619,7 +623,7 @@ class TestCreateView(OnyxTestCase):
             )
             payload["sample_id"] = response.json()["data"]["sample_id"]
             payload["run_name"] = response.json()["data"]["run_name"]
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_int in bad_ints:
@@ -666,7 +670,7 @@ class TestCreateView(OnyxTestCase):
             )
             payload["sample_id"] = response.json()["data"]["sample_id"]
             payload["run_name"] = response.json()["data"]["run_name"]
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_float in bad_floats:
@@ -723,7 +727,7 @@ class TestCreateView(OnyxTestCase):
                 payload["collection_month"] = None
             else:
                 payload["collection_month"] = expected.strftime("%Y-%m")
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_yearmonth in bad_yearmonths:
@@ -781,7 +785,7 @@ class TestCreateView(OnyxTestCase):
                 payload["submission_date"] = None
             else:
                 payload["submission_date"] = expected.strftime("%Y-%m-%d")
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_date in bad_dates:
@@ -828,7 +832,7 @@ class TestCreateView(OnyxTestCase):
             )
             payload["sample_id"] = response.json()["data"]["sample_id"]
             payload["run_name"] = response.json()["data"]["run_name"]
-            _test_record(self, payload, instance, created=True)
+            self.assertEqualRecords(payload, instance, created=True)
             TestModel.objects.all().delete()
 
         for bad_bool in bad_bools:

--- a/onyx/data/tests/views/test_delete.py
+++ b/onyx/data/tests/views/test_delete.py
@@ -8,6 +8,10 @@ from projects.testproject.models import TestModel
 class TestDeleteView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the admin user
+        self.client.force_authenticate(self.admin_user)  # type: ignore
+
         self.endpoint = lambda climb_id: reverse(
             "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},

--- a/onyx/data/tests/views/test_fields.py
+++ b/onyx/data/tests/views/test_fields.py
@@ -6,6 +6,10 @@ from ..utils import OnyxTestCase
 class TestFieldsView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse(
             "projects.testproject.fields", kwargs={"code": self.project.code}
         )

--- a/onyx/data/tests/views/test_filter.py
+++ b/onyx/data/tests/views/test_filter.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxDataTestCase
 from projects.testproject.models import TestModel, TestModelRecord
+from data.fields import flatten_fields
 
 
 # TODO: Tests of nested filtering for each field type
@@ -170,7 +171,32 @@ class TestFilterView(OnyxDataTestCase):
         Test including and excluding fields on a filter.
         """
 
-        pass  # TODO
+        # Get all fields
+        response = self.client.get(self.endpoint)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        fields = flatten_fields(response.json()["data"])
+
+        # Test including fields
+        response = self.client.get(
+            self.endpoint, data={"include": ["run_name", "score", "submission_date"]}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            sorted(flatten_fields(response.json()["data"])),
+            ["run_name", "score", "submission_date"],
+        )
+
+        # Test excluding fields
+        response = self.client.get(
+            self.endpoint, data={"exclude": ["run_name", "score", "submission_date"]}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            sorted(flatten_fields(response.json()["data"])),
+            sorted(
+                [x for x in fields if x not in ["run_name", "score", "submission_date"]]
+            ),
+        )
 
     def test_include_exclude_bad_field(self):
         """

--- a/onyx/data/tests/views/test_history.py
+++ b/onyx/data/tests/views/test_history.py
@@ -11,6 +11,10 @@ from projects.testproject.models import TestModel
 class TestHistoryView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the admin user
+        self.client.force_authenticate(self.admin_user)  # type: ignore
+
         self.endpoint = lambda climb_id: reverse(
             "projects.testproject.history.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},
@@ -32,7 +36,7 @@ class TestHistoryView(OnyxTestCase):
         self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
         self.assertEqual(len(response.json()["data"]["history"]), 1)
         self.assertEqual(
-            response.json()["data"]["history"][0]["username"], self.user.username
+            response.json()["data"]["history"][0]["username"], self.admin_user.username
         )
         self.assertEqual(
             response.json()["data"]["history"][0]["action"], Actions.ADD.label
@@ -78,7 +82,7 @@ class TestHistoryView(OnyxTestCase):
         self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
         self.assertEqual(len(response.json()["data"]["history"]), 2)
         for diff in response.json()["data"]["history"]:
-            self.assertEqual(diff["username"], self.user.username)
+            self.assertEqual(diff["username"], self.admin_user.username)
 
         self.assertEqual(
             response.json()["data"]["history"][0]["action"], Actions.ADD.label
@@ -164,7 +168,7 @@ class TestHistoryView(OnyxTestCase):
         self.assertEqual(response.json()["data"]["climb_id"], self.climb_id)
         self.assertEqual(len(response.json()["data"]["history"]), 3)
         for diff in response.json()["data"]["history"]:
-            self.assertEqual(diff["username"], self.user.username)
+            self.assertEqual(diff["username"], self.admin_user.username)
 
         self.assertEqual(
             response.json()["data"]["history"][0]["action"], Actions.ADD.label

--- a/onyx/data/tests/views/test_identify.py
+++ b/onyx/data/tests/views/test_identify.py
@@ -7,9 +7,16 @@ from data.models import Anonymiser
 from projects.testproject.models import TestModel
 
 
+# TODO: Test permissions to retrieve identifiers for users from different sites
+
+
 class TestIdentifyView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the admin user
+        self.client.force_authenticate(self.admin_staff)  # type: ignore
+
         self.endpoint = lambda field: reverse(
             "projects.testproject.identify.field",
             kwargs={"code": self.project.code, "field": field},

--- a/onyx/data/tests/views/test_lookups.py
+++ b/onyx/data/tests/views/test_lookups.py
@@ -7,6 +7,10 @@ from ...types import OnyxLookup, OnyxType
 class TestLookupsView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse("projects.lookups")
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_projects.py
+++ b/onyx/data/tests/views/test_projects.py
@@ -1,12 +1,15 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 from ..utils import OnyxTestCase
-from ...actions import Actions
 
 
 class TestProjectsView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse("projects")
 
     def test_basic(self):
@@ -21,9 +24,12 @@ class TestProjectsView(OnyxTestCase):
             [
                 {
                     "project": "testproject",
-                    "scope": "admin",
+                    "scope": "analyst",
                     "actions": [
-                        action.label for action in Actions if action != Actions.ACCESS
+                        "get",
+                        "list",
+                        "filter",
+                        "history",
                     ],
                 }
             ],

--- a/onyx/data/tests/views/test_types.py
+++ b/onyx/data/tests/views/test_types.py
@@ -7,6 +7,10 @@ from ...types import OnyxType
 class TestTypesView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the analyst user
+        self.client.force_authenticate(self.analyst_user)  # type: ignore
+
         self.endpoint = reverse("projects.types")
 
     def test_basic(self):

--- a/onyx/data/tests/views/test_update.py
+++ b/onyx/data/tests/views/test_update.py
@@ -9,6 +9,10 @@ from projects.testproject.models import TestModel
 class TestUpdateView(OnyxTestCase):
     def setUp(self):
         super().setUp()
+
+        # Authenticate as the admin user
+        self.client.force_authenticate(self.admin_user)  # type: ignore
+
         self.endpoint = lambda climb_id: reverse(
             "projects.testproject.climb_id",
             kwargs={"code": self.project.code, "climb_id": climb_id},

--- a/onyx/projects/testproject/project.json
+++ b/onyx/projects/testproject/project.json
@@ -10,10 +10,27 @@
                 {
                     "action": "add",
                     "fields": [
-                        "is_published",
                         "site",
                         "sample_id",
-                        "run_name",
+                        "run_name"
+                    ]
+                },
+                {
+                    "action": [
+                        "history",
+                        "change"
+                    ],
+                    "fields": [
+                        "is_suppressed"
+                    ]
+                },
+                {
+                    "action": [
+                        "add",
+                        "change"
+                    ],
+                    "fields": [
+                        "is_published",
                         "collection_month",
                         "received_month",
                         "char_max_length_20",
@@ -47,8 +64,10 @@
                         "history"
                     ],
                     "fields": [
-                        "climb_id",
                         "is_published",
+                        "is_suppressed",
+                        "is_site_restricted",
+                        "climb_id",
                         "published_date",
                         "site",
                         "sample_id",
@@ -86,9 +105,27 @@
                     ]
                 },
                 {
-                    "action": "change",
+                    "action": "delete",
+                    "fields": []
+                }
+            ]
+        },
+        {
+            "scope": "analyst",
+            "permissions": [
+                {
+                    "action": [
+                        "get",
+                        "list",
+                        "filter",
+                        "history"
+                    ],
                     "fields": [
-                        "is_published",
+                        "climb_id",
+                        "published_date",
+                        "site",
+                        "sample_id",
+                        "run_name",
                         "collection_month",
                         "received_month",
                         "char_max_length_20",
@@ -113,10 +150,6 @@
                         "records__score_c",
                         "records__test_result"
                     ]
-                },
-                {
-                    "action": "delete",
-                    "fields": []
                 }
             ]
         }


### PR DESCRIPTION
- Better control over user type used in tests: users can be created up in `OnyxTestCase`, and then `force_authenticate` must be called on each test to authenticate as a given user.
- Added `analyst` user permissions in `testproject`, and switched to an `analyst` user where possible for testing.
- Added tests for nested filtering on text fields, and on query endpoint.
- Tests for include/exclude fields on filtering.
- Test suppressed/unpublished/site restricted records on filtering.