### PR TITLE
Project command fix

### DIFF
--- a/onyx/data/management/commands/project.py
+++ b/onyx/data/management/commands/project.py
@@ -1,4 +1,5 @@
 import json
+import copy
 from typing import Optional, List
 from pydantic import BaseModel, field_validator
 from django.core.management import base
@@ -139,7 +140,7 @@ class Command(base.BaseCommand):
                                     existing_group.permissions.extend(group.permissions)
                                     break
                             else:
-                                groups.append(group)
+                                groups.append(copy.deepcopy(group))
 
                     if content.choices:
                         choices.extend(content.choices)


### PR DESCRIPTION
An issue was found when defining permissions for multiple projects which shared the same `ProjectContentsConfig`. 

As the input `GroupConfig` objects where being directly modified (if a given scope appeared in multiple contents entries, the permissions were extended onto the first object in that scope), this meant permissions for a project defined before another in the `ProjectConfig` would bleed over into the following ones.

This is fixed by copying the permissions individually into a mapping from scope to permission for each project, then re-defining new `GroupConfig` objects before passing them into the `set_groups` method.