### PR TITLE
Search functionality in dedicated function, site choice descriptions populated by `Site` model descriptions

### DIFF
--- a/onyx/data/search.py
+++ b/onyx/data/search.py
@@ -1,0 +1,35 @@
+from django.db.models import Q
+
+
+def build_search(search_str: str, search_fields: list[str]) -> Q:
+    """
+    Build a Q object that checks for presence of the user's search against the search fields.
+
+    Args:
+        search_str: The user's search string.
+        search_fields: The fields to search against.
+
+    Returns:
+        A Q object representing the search.
+    """
+
+    # Split the search string into individual words
+    words = []
+    for word in search_str.split():
+        w = word.strip().strip("'").strip('"').strip()
+        if w:
+            words.append(w)
+
+    # Form the Q object for the search
+    search = Q()
+    for word in words:
+        s = Q()
+        for field in search_fields:
+            if field == "site":
+                s |= Q(**{f"{field}__code__icontains": word})
+            else:
+                s |= Q(**{f"{field}__icontains": word})
+        search &= s
+
+    # Return the search object
+    return search

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -14,6 +14,7 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSetMixin
 from utils.functions import parse_permission, pydantic_to_drf_error
 from accounts.permissions import Approved, ProjectApproved, IsSiteMember
+from accounts.models import Site
 from .models import Project, Choice, ProjectRecord, Anonymiser, Analysis
 from .serializers import (
     HistoryDiffSerializer,
@@ -334,6 +335,19 @@ class ChoicesView(ProjectAPIView):
                 "is_active",
             )
         }
+
+        # Populate site choice descriptions from the Site model description
+        if onyx_field.field_name == "site":
+            descriptions = {
+                site_code: description
+                for site_code, description in Site.objects.values_list(
+                    "code", "description"
+                )
+            }
+
+            for choice, data in choices.items():
+                if not data["description"]:
+                    data["description"] = descriptions.get(choice.lower(), "")
 
         # Return choices for the field
         return Response(choices)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.18.3"
+version = "0.18.4"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.brier@outlook.com>"]
 license = "LICENSE"


### PR DESCRIPTION
- Search logic moved to `build_search` function, and is now supported for both records and analyses.
- Site descriptions are now populated on the `choices` endpoint by taking the sites corresponding description from the `Site` model.