### PR TITLE
Fixed duplicate users when on `site-users` endpoint

### DIFF
--- a/onyx/accounts/views.py
+++ b/onyx/accounts/views.py
@@ -122,12 +122,16 @@ class SiteUsersView(ListAPIView):
             "projectgroup__project", flat=True
         ).distinct()
 
-        users = User.objects.filter(
-            is_active=True,
-            is_approved=True,
-            site=self.request.user.site,
-            groups__projectgroup__project__in=projects,
-        ).order_by("-date_joined")
+        users = (
+            User.objects.filter(
+                is_active=True,
+                is_approved=True,
+                site=self.request.user.site,
+                groups__projectgroup__project__in=projects,
+            )
+            .distinct()
+            .order_by("-date_joined")
+        )
 
         return users
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "onyx"
-version = "0.18.4"
+version = "0.18.5"
 description = "API for pathogen metadata."
-authors = ["Thomas Brier <t.brier@outlook.com>"]
+authors = ["Thomas Brier <t.o.brier@bham.ac.uk>"]
 license = "LICENSE"
 readme = "README.md"
 


### PR DESCRIPTION
* The `site-users` endpoint returned duplicate rows of site users when they shared more than one project with the requesting user. This PR fixes that with a `.distinct()` call. 
* The `authors` email is also updated to not use my personal one :)