### PR TITLE
`override` option in `project` command input JSON file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "onyx"
-version = "0.18.5"
+version = "0.18.6"
 description = "API for pathogen metadata."
 authors = ["Thomas Brier <t.o.brier@bham.ac.uk>"]
 license = "LICENSE"


### PR DESCRIPTION
This PR adds the ability to provide an `override` key in a `ChoiceConfig` object in the input JSON file. If set to `true`, this means the set of choices provided for the given field will override any other options provided in separate `ProjectContentsConfig` objects.