### PR TITLE
Analysis uploader group

### DIFF
--- a/onyx/data/management/commands/project.py
+++ b/onyx/data/management/commands/project.py
@@ -197,6 +197,34 @@ def get_analysis_groups(project: str) -> List[GroupConfig]:
         ),
         GroupConfig(
             **{
+                "scope": Scopes.ANALYSIS_UPLOADER.label,
+                "object_type": Objects.ANALYSIS.label,
+                "permissions": [
+                    {
+                        "action": ["add", "testadd", "change", "testchange"],
+                        "fields": [
+                            "analysis_date",
+                            "name",
+                            "description",
+                            "pipeline_name",
+                            "pipeline_url",
+                            "pipeline_version",
+                            "pipeline_command",
+                            "methods",
+                            "result",
+                            "result_metrics",
+                            "report",
+                            "outputs",
+                            "upstream_analyses",
+                            "identifiers",
+                            f"{project}_records",
+                        ],
+                    },
+                ],
+            }
+        ),
+        GroupConfig(
+            **{
                 "scope": Scopes.ANALYST.label,
                 "object_type": Objects.ANALYSIS.label,
                 "permissions": [

--- a/onyx/data/models.py
+++ b/onyx/data/models.py
@@ -9,7 +9,7 @@ from django.core import checks
 from django.core.checks.messages import CheckMessage
 from accounts.models import Site, User
 from utils.fields import StrippedCharField, LowerCharField, UpperCharField, SiteField
-from utils.constraints import unique_together, optional_value_group
+from utils.constraints import unique_together, optional_value_group, non_futures
 from simple_history.models import HistoricalRecords
 from .types import OnyxLookup
 
@@ -315,6 +315,9 @@ class Analysis(PrimaryRecord):
             ),
             optional_value_group(
                 fields=["report", "outputs"],
+            ),
+            non_futures(
+                fields=["analysis_date"],
             ),
         ]
 

--- a/onyx/data/serializers.py
+++ b/onyx/data/serializers.py
@@ -455,6 +455,9 @@ class AnalysisSerializer(PrimaryRecordSerializer):
             PrimaryRecordSerializer.OnyxMeta.optional_value_groups
             + [["report", "outputs"]]
         )
+        non_futures = PrimaryRecordSerializer.OnyxMeta.non_futures + [
+            "analysis_date",
+        ]
 
 
 # TODO: Race condition testing + preventions.

--- a/onyx/data/types.py
+++ b/onyx/data/types.py
@@ -24,6 +24,7 @@ class Scopes(Enum):
     ADMIN = "admin"
     UPLOADER = "uploader"
     ANALYST = "analyst"
+    ANALYSIS_UPLOADER = "analysis_uploader"
 
     def __init__(self, label: str) -> None:
         self.label = label


### PR DESCRIPTION
- Added project group for creating/updating analyses only.
- Fixed `analysis_date` validation by ensuring validation for non-future dates.