### PR TITLE
Action descriptions in field permission errors

### DIFF
--- a/onyx/data/fields.py
+++ b/onyx/data/fields.py
@@ -1,4 +1,5 @@
 from typing import Any
+from functools import cached_property
 from django.db import models
 from django.contrib.postgres.fields import ArrayField
 from rest_framework import exceptions
@@ -12,7 +13,7 @@ from utils.fields import (
 from utils.functions import get_suggestions, get_permission, parse_permission
 from accounts.models import User
 from .models import Choice, Project, PrimaryRecord
-from .types import Actions, OnyxLookup, OnyxType
+from .types import Actions, Objects, OnyxLookup, OnyxType
 
 
 class OnyxField:
@@ -166,70 +167,57 @@ class OnyxField:
 
 class FieldHandler:
     """
-    Class that does the following for a given project, action and user:
+    Class that does the following for a given `project`, `action`, `object_type`, `model` and `user`:
 
-    - Provide functions for retrieving fields that can be actioned on.
     - Resolves fields (converts field strings into `OnyxField` objects).
-    - Checks whether the user has permission to action on the resolved fields.
+    - Checks whether the `user` has permission to perform the `action` on the resolved fields.
+    - Provides functions for retrieving fields that can be actioned on.
     """
 
-    __slots__ = (
-        "app_label",
-        "project",
-        "action",
-        "object_type",
-        "model",
-        "user",
-        "fields",
-    )
+    project: Project
+    action: Actions
+    object_type: Objects
+    model: type[PrimaryRecord]
+    user: User
 
     def __init__(
         self,
         project: Project,
         action: Actions,
-        object_type: str,
+        object_type: Objects,
         model: type[PrimaryRecord],
         user: User,
     ) -> None:
-        self.app_label = project.content_type.app_label
         self.project = project
         self.action = action
         self.object_type = object_type
         self.model = model
         self.user = user
-        self.fields = None
 
-    def get_fields(
-        self,
-    ) -> list[str]:
+    @cached_property
+    def fields(self) -> list[str]:
         """
-        Get all fields that can be actioned on.
+        All fields that the user can perform the handler's action on.
 
         Returns:
             The list of fields that the user can action on.
         """
 
-        # If fields have not been cached, retrieve them
-        if self.fields is None:
-            fields = []
+        action_fields = []
+        for permission in self.user.get_all_permissions():
+            app_label, action, project, object_type, field = parse_permission(
+                permission
+            )
+            if (
+                app_label == self.project.content_type.app_label
+                and action == self.action.label
+                and project == self.project.code
+                and object_type == self.object_type.label
+                and field
+            ):
+                action_fields.append(field)
 
-            for permission in self.user.get_all_permissions():
-                app_label, action, project, object_type, field = parse_permission(
-                    permission
-                )
-
-                if (
-                    app_label == self.app_label
-                    and action == self.action.label
-                    and project == self.project.code
-                    and object_type == self.object_type
-                    and field
-                ):
-                    fields.append(field)
-
-            self.fields = fields
-
-        return self.fields
+        return action_fields
 
     def field_suggestions(self, field, message_prefix=None) -> str:
         """
@@ -250,7 +238,7 @@ class FieldHandler:
 
         suggestions = get_suggestions(
             field,
-            options=self.get_fields(),
+            options=self.fields,
             n=1,
             message_prefix=message_prefix,
         )
@@ -270,10 +258,10 @@ class FieldHandler:
         # Check the user's permission to access the field
         # If the user does not have permission, tell them it is unknown
         field_access_permission = get_permission(
-            app_label=self.app_label,
+            app_label=self.project.content_type.app_label,
             action=Actions.ACCESS.label,
             code=self.project.code,
-            object_type=self.object_type,
+            object_type=self.object_type.label,
             field=onyx_field.field_path,
         )
 
@@ -285,10 +273,10 @@ class FieldHandler:
         # Check the user's permission to perform action on the field
         # If the user does not have permission, tell them it is not allowed
         field_action_permission = get_permission(
-            app_label=self.app_label,
+            app_label=self.project.content_type.app_label,
             action=self.action.label,
             code=self.project.code,
-            object_type=self.object_type,
+            object_type=self.object_type.label,
             field=onyx_field.field_path,
         )
 

--- a/onyx/data/views.py
+++ b/onyx/data/views.py
@@ -142,7 +142,7 @@ class PrimaryRecordAPIView(APIView):
         self.handler = FieldHandler(
             project=self.project,
             action=self.project_action,
-            object_type=self.object_type.label,
+            object_type=self.object_type,
             model=self.model,
             user=request.user,
         )
@@ -151,7 +151,7 @@ class PrimaryRecordAPIView(APIView):
         self.qs = init_project_queryset(
             model=self.model,
             user=request.user,
-            fields=self.handler.get_fields(),
+            fields=self.handler.fields,
         )
 
         # Build request query parameters
@@ -233,7 +233,7 @@ class AnalysisAPIView(PrimaryRecordAPIView):
         self.handler = FieldHandler(
             project=self.project,
             action=self.project_action,
-            object_type=self.object_type.label,
+            object_type=self.object_type,
             model=self.model,
             user=request.user,
         )
@@ -243,7 +243,7 @@ class AnalysisAPIView(PrimaryRecordAPIView):
         self.qs = init_project_queryset(
             model=self.model,
             user=request.user,
-            fields=self.handler.get_fields(),
+            fields=self.handler.fields,
         ).filter(project=self.project)
 
 
@@ -340,7 +340,7 @@ class FieldsView(PrimaryRecordAPIView):
         """
 
         # Get all accessible fields
-        fields = self.handler.get_fields()
+        fields = self.handler.fields
 
         # Get all actions for each field (excluding access)
         actions_map = {}
@@ -482,7 +482,7 @@ class HistoryView(PrimaryRecordAPIView):
         history = list(instance.history.all().order_by("history_date"))  #  type: ignore
 
         # Mapping of all history fields to their corresponding OnyxField objects
-        fields = self.handler.resolve_fields(self.handler.get_fields())
+        fields = self.handler.resolve_fields(self.handler.fields)
 
         # Non-nested fields to include in the history
         included_fields = [
@@ -764,7 +764,7 @@ class PrimaryRecordViewSet(ViewSetMixin, PrimaryRecordAPIView):
 
         # Fields returned in response
         fields = include_exclude_fields(
-            fields=self.handler.get_fields(),
+            fields=self.handler.fields,
             include=self.include,
             exclude=self.exclude,
         )
@@ -797,7 +797,7 @@ class PrimaryRecordViewSet(ViewSetMixin, PrimaryRecordAPIView):
         filter_handler = FieldHandler(
             project=self.project,
             action=Actions.FILTER,
-            object_type=self.object_type.label,
+            object_type=self.object_type,
             model=self.model,
             user=request.user,
         )
@@ -855,7 +855,7 @@ class PrimaryRecordViewSet(ViewSetMixin, PrimaryRecordAPIView):
 
         # Fields returned in response
         fields = include_exclude_fields(
-            fields=self.handler.get_fields(),
+            fields=self.handler.fields,
             include=self.include,
             exclude=self.exclude,
         )
@@ -1126,7 +1126,7 @@ class RecordAnalysesView(AnalysisAPIView):
         record_handler = FieldHandler(
             project=self.project,
             action=Actions.GET,
-            object_type=Objects.RECORD.label,
+            object_type=Objects.RECORD,
             model=record_model,
             user=request.user,
         )
@@ -1135,7 +1135,7 @@ class RecordAnalysesView(AnalysisAPIView):
         record_qs = init_project_queryset(
             model=record_model,
             user=request.user,
-            fields=record_handler.get_fields(),
+            fields=record_handler.fields,
         )
 
         # Check the instance exists
@@ -1155,7 +1155,7 @@ class RecordAnalysesView(AnalysisAPIView):
         serializer = self.serializer_cls(
             qs,
             many=True,
-            fields=unflatten_fields(self.handler.get_fields()),
+            fields=unflatten_fields(self.handler.fields),
         )
 
         # Return response with data
@@ -1174,7 +1174,7 @@ class AnalysisRecordsView(ProjectRecordAPIView):
         analysis_handler = FieldHandler(
             project=self.project,
             action=Actions.GET,
-            object_type=Objects.ANALYSIS.label,
+            object_type=Objects.ANALYSIS,
             model=Analysis,
             user=request.user,
         )
@@ -1183,7 +1183,7 @@ class AnalysisRecordsView(ProjectRecordAPIView):
         analysis_qs = init_project_queryset(
             model=Analysis,
             user=request.user,
-            fields=analysis_handler.get_fields(),
+            fields=analysis_handler.fields,
         )
 
         # Check the instance exists


### PR DESCRIPTION
This PR changes the `FieldHandler` to use an action's `description` when raising field permission errors, mirroring the messages of endpoint permission errors. 

E.g for the command:
```
$ onyx create {project} --test --field published_date=2025-01-01
```
The response changes from:
```
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────╮
│ {                                                                                                 │
│     "published_date": [                                                                           │
│         "You cannot testadd this field. Perhaps you meant: is_published"                          │
│     ]                                                                                             │
│ }                                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
```
to:
```
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────╮
│ {                                                                                                 │
│     "published_date": [                                                                           │
│         "You cannot test creating this field. Perhaps you meant: is_published"                    │
│     ]                                                                                             │
│ }                                                                                                 │
╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
```
