### PR TITLE
API rate limiting

### DIFF
--- a/onyx/internal/throttling.py
+++ b/onyx/internal/throttling.py
@@ -1,0 +1,21 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class BurstRateThrottle(UserRateThrottle):
+    scope = "burst"
+
+    def allow_request(self, request, view):
+        if request.user.is_staff:
+            return True
+        else:
+            return super().allow_request(request, view)
+
+
+class SustainedRateThrottle(UserRateThrottle):
+    scope = "sustained"
+
+    def allow_request(self, request, view):
+        if request.user.is_staff:
+            return True
+        else:
+            return super().allow_request(request, view)

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -202,6 +202,9 @@ REST_FRAMEWORK = {
     "PAGE_SIZE": 1000,
 }
 
+if "test" in sys.argv:
+    REST_FRAMEWORK["DEFAULT_THROTTLE_CLASSES"] = []
+
 REST_KNOX = {
     "TOKEN_TTL": timedelta(weeks=1),
     "TOKEN_LIMIT_PER_USER": None,

--- a/onyx/onyx/settings.py
+++ b/onyx/onyx/settings.py
@@ -187,6 +187,16 @@ REST_FRAMEWORK = {
     "DEFAULT_PARSER_CLASSES": [
         "rest_framework.parsers.JSONParser",
     ],
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "internal.throttling.BurstRateThrottle",
+        "internal.throttling.SustainedRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "10/min",
+        "burst": "10/min",
+        "sustained": "10000/day",
+    },
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
     "DEFAULT_PAGINATION_CLASS": None,
     "PAGE_SIZE": 1000,


### PR DESCRIPTION
- This PR implements rate limiting on non-staff users, however is not complete as there is no cache setup yet, and the rates themselves should be reconsidered.
- May also want to consider different limits for different endpoints.
- Addresses #294 